### PR TITLE
Prevent empty `+()` when mapping to ASTs

### DIFF
--- a/src/expressions.jl
+++ b/src/expressions.jl
@@ -774,7 +774,7 @@ function map_expression_to_ast(
             push!(ex.args, Expr(:call, :*, c, var_mapper(v)))
         end
     end
-    if !iszero(aff.constant) || isempty(ex.args)
+    if !iszero(aff.constant) || isempty(ex.args[2:end])
         push!(ex.args, aff.constant)
     end
     return ex
@@ -795,7 +795,7 @@ function map_expression_to_ast(
         end
     end
     aff_ex = map_expression_to_ast(var_mapper, op_mapper, quad.aff)
-    if aff_ex.args != [:+, 0.0] || isempty(ex.args)
+    if aff_ex.args != [:+, 0.0] || isempty(ex.args[2:end])
         append!(ex.args, aff_ex.args[2:end])
     end
     return ex

--- a/src/expressions.jl
+++ b/src/expressions.jl
@@ -774,7 +774,7 @@ function map_expression_to_ast(
             push!(ex.args, Expr(:call, :*, c, var_mapper(v)))
         end
     end
-    if !iszero(aff.constant)
+    if !iszero(aff.constant) || isempty(ex.args)
         push!(ex.args, aff.constant)
     end
     return ex
@@ -794,7 +794,10 @@ function map_expression_to_ast(
             push!(ex.args, Expr(:call, :*, c, var_mapper(v1), var_mapper(v2)))
         end
     end
-    append!(ex.args, map_expression_to_ast(var_mapper, op_mapper, quad.aff).args[2:end])
+    aff_ex = map_expression_to_ast(var_mapper, op_mapper, quad.aff)
+    if aff_ex.args != [:+, 0.0] || isempty(ex.args)
+        append!(ex.args, aff_ex.args[2:end])
+    end
     return ex
 end
 

--- a/test/expressions.jl
+++ b/test/expressions.jl
@@ -663,6 +663,9 @@ end
     aff = 2z + y + 42
     quad = z^2 + 3 * z * y + 2z
     nlp = (sin(z) + aff) ^ 3.4
+    aff0 = zero(GenericAffExpr{Float64, GeneralVariableRef})
+    quad2 = 2 * z^2
+    quad0 = zero(GenericQuadExpr{Float64, GeneralVariableRef})
     jm = Model()
     @variable(jm, x)
     @variable(jm, w)
@@ -679,10 +682,13 @@ end
     # test AffExpr
     @testset "AffExpr" begin
         @test map_expression_to_ast(vmap, aff) == :(2 * $x + $w + 42)
+        @test map_expression_to_ast(vmap, aff0) == :(+(0))
     end
     # test QuadExpr 
     @testset "QuadExpr" begin
         @test map_expression_to_ast(vmap, quad) == :($x * $x + 3 * $x * $w + 2 * $x)
+        @test map_expression_to_ast(vmap, quad2) == :(2 * $x * $x)
+        @test map_expression_to_ast(vmap, quad0) == :(+(0))
     end
     # test GenericNonlinearExpr
     @testset "GenericNonlinearExpr" begin

--- a/test/expressions.jl
+++ b/test/expressions.jl
@@ -687,7 +687,7 @@ end
     # test QuadExpr 
     @testset "QuadExpr" begin
         @test map_expression_to_ast(vmap, quad) == :($x * $x + 3 * $x * $w + 2 * $x)
-        @test map_expression_to_ast(vmap, quad2) == :(2 * $x * $x)
+        @test map_expression_to_ast(vmap, quad2) == :(+(2 * $x * $x))
         @test map_expression_to_ast(vmap, quad0) == :(+(0))
     end
     # test GenericNonlinearExpr


### PR DESCRIPTION
This fixes a bug when building ASTs to avoid the case where we get `:(+())` which is not valid Julia code.
