### PR TITLE
Implement `constant_over_collocation`

### DIFF
--- a/docs/src/examples/Optimal Control/pandemic_control.jl
+++ b/docs/src/examples/Optimal Control/pandemic_control.jl
@@ -155,10 +155,10 @@ add_supports(t, extra_ts)
 @constraint(model, imax_constr, i ≤ i_max)
 
 # ## Adjust Degrees of Freedom
-# Since we are using `OrthogonalCollocation`, this introduces additional collocation points 
+# Since we are using [`OrthogonalCollocation`](@ref), this introduces additional collocation points 
 # for `t`. These in turn, will artificially increase the degrees of freedom for `u`. Thus, 
-# we will treat `u` as a piecewise constant function that held constant over the internal 
-# collocation nodes:
+# we will treat `u` as a piecewise constant function that is held constant over the internal 
+# collocation nodes via [`constant_over_collocation`](@ref constant_over_collocation(::InfiniteVariableRef, ::GeneralVariableRef)):
 constant_over_collocation(u, t)
 
 # ## Display the Infinite Model

--- a/docs/src/examples/Optimal Control/pandemic_control.jl
+++ b/docs/src/examples/Optimal Control/pandemic_control.jl
@@ -13,11 +13,10 @@
 # This model is formalized as:
 # ```math 
 # \begin{gathered}
-# \frac{ds(t)}{dt} = (u(t) - 1)\beta si(t) \\
-# \frac{de(t)}{dt} = (1 - u(t))\beta si(t) - \xi e(t) \\
+# \frac{ds(t)}{dt} = (u(t) - 1)\beta s(t)i(t) \\
+# \frac{de(t)}{dt} = (1 - u(t))\beta s(t)i(t) - \xi e(t) \\
 # \frac{di(t)}{dt} = \xi e(t) - \gamma i(t)\\
 # \frac{dr(t)}{dt} = \gamma i(t) \\
-# si(t) = s(t) i(t)
 # \end{gathered}
 # ```
 # where ``s(t)`` is the susceptible population, ``e(t)`` is the exposed population, 
@@ -36,11 +35,10 @@
 # ```math 
 # \begin{aligned}
 # &&\min_{} &&& \int_{t \in \mathcal{D}_{t}} u(t) dt \\
-# && \text{s.t.} &&& \frac{\partial s(t, \xi)}{\partial t} = (u(t) - 1)\beta si(t, \xi), && \forall t \in \mathcal{D}_{t}, \xi \in \mathcal{D}_{\xi} \\
-# &&&&& \frac{\partial e(t, \xi)}{\partial t} = (1 - u(t))\beta si(t, \xi) - \xi e(t, \xi), && \forall t \in \mathcal{D}_{t}, \xi \in \mathcal{D}_{\xi} \\
+# && \text{s.t.} &&& \frac{\partial s(t, \xi)}{\partial t} = (u(t) - 1)\beta s(t, \xi)i(t, \xi), && \forall t \in \mathcal{D}_{t}, \xi \in \mathcal{D}_{\xi} \\
+# &&&&& \frac{\partial e(t, \xi)}{\partial t} = (1 - u(t))\beta s(t, \xi)i(t, \xi) - \xi e(t, \xi), && \forall t \in \mathcal{D}_{t}, \xi \in \mathcal{D}_{\xi} \\
 # &&&&& \frac{\partial i(t, \xi)}{\partial t} = \xi e(t, \xi) - \gamma i(t, \xi), && \forall t \in \mathcal{D}_{t}, \xi \in \mathcal{D}_{\xi} \\
 # &&&&& \frac{\partial r(t, \xi)}{\partial t} = \gamma i(t, \xi), && \forall t \in \mathcal{D}_{t}, \xi \in \mathcal{D}_{\xi} \\
-# &&&&& si(t, \xi) = s(t, \xi) i(t, \xi), && \forall \forall t \in \mathcal{D}_{t}, \xi \in \mathcal{D}_{\xi} \\
 # &&&&& s(0, \xi) = s_0, e(0, \xi) = e_0, i(0, \xi) = i_0, r(0, \xi) = r_0, && \forall \xi \in \mathcal{D}_{\xi} \\
 # &&&&& i(t, \xi) \leq i_{max}, && \forall t \in \mathcal{D}_{t}, \xi \in \mathcal{D}_{\xi} \\
 # &&&&& u(t) \in [0, 0.8] \\
@@ -100,7 +98,7 @@ model = InfiniteModel(Ipopt.Optimizer);
 # - specify that the number of random scenarios should equal `num_samples`
 # - add `extra_ts` as extra time points
 @infinite_parameter(model, t ∈ [t0, tf], num_supports = 51, 
-                    derivative_method = OrthogonalCollocation(2))
+                    derivative_method = OrthogonalCollocation(3))
 @infinite_parameter(model, ξ ~ Uniform(ξ_min, ξ_max), num_supports = num_samples)
 add_supports(t, extra_ts)
 
@@ -110,13 +108,11 @@ add_supports(t, extra_ts)
 # - ``e(t, \xi) \geq 0``
 # - ``i(t, \xi) \geq 0``
 # - ``r(t, \xi) \geq 0``
-# - ``si(t, \xi)``
 # - ``0 \leq u(t) \leq 0.8``
 @variable(model, s ≥ 0, Infinite(t, ξ))
 @variable(model, e ≥ 0, Infinite(t, ξ))
 @variable(model, i ≥ 0, Infinite(t, ξ))
 @variable(model, r ≥ 0, Infinite(t, ξ))
-@variable(model, si, Infinite(t, ξ))
 @variable(model, 0 ≤ u ≤ 0.8, Infinite(t), start = 0.2)
 
 # ## Objective Definition
@@ -137,7 +133,6 @@ add_supports(t, extra_ts)
 # &&& \frac{\partial e(t, \xi)}{\partial t} = (1 - u(t))\beta si(t, \xi) - \xi e(t, \xi), && \forall t \in \mathcal{D}_{t}, \xi \in \mathcal{D}_{\xi} \\
 # &&& \frac{\partial i(t, \xi)}{\partial t} = \xi e(t, \xi) - \gamma i(t, \xi), && \forall t \in \mathcal{D}_{t}, \xi \in \mathcal{D}_{\xi} \\
 # &&& \frac{\partial r(t, \xi)}{\partial t} = \gamma i(t, \xi), && \forall t \in \mathcal{D}_{t}, \xi \in \mathcal{D}_{\xi} \\
-# &&& si(t, \xi) = s(t, \xi) i(t, \xi), && \forall \forall t \in \mathcal{D}_{t}, \xi \in \mathcal{D}_{\xi}, \\
 # \end{aligned}
 # ```
 # and the infection limit constraint:
@@ -151,14 +146,20 @@ add_supports(t, extra_ts)
 @constraint(model, r(0, ξ) == r0)
 
 ## Define the SEIR equations
-@constraint(model, s_constr, ∂(s, t) == -(1 - u) * β * si)
-@constraint(model, e_constr, ∂(e, t) == (1 - u) * β * si - ξ * e)
+@constraint(model, s_constr, ∂(s, t) == -(1 - u) * β * s * i)
+@constraint(model, e_constr, ∂(e, t) == (1 - u) * β * s * i - ξ * e)
 @constraint(model, i_constr, ∂(i, t) == ξ * e - γ * i)
 @constraint(model, r_constr, ∂(r, t) == γ * i)
-@constraint(model, si == s * i)
 
 ## Define the infection rate limit
 @constraint(model, imax_constr, i ≤ i_max)
+
+# ## Adjust Degrees of Freedom
+# Since we are using `OrthogonalCollocation`, this introduces additional collocation points 
+# for `t`. These in turn, will artificially increase the degrees of freedom for `u`. Thus, 
+# we will treat `u` as a piecewise constant function that held constant over the internal 
+# collocation nodes:
+constant_over_collocation(u, t)
 
 # ## Display the Infinite Model
 # Let's display `model` now that it is fully defined:

--- a/docs/src/guide/derivative.md
+++ b/docs/src/guide/derivative.md
@@ -46,10 +46,10 @@ as needed. For example, we can define the following:
 julia> d1 = deriv(y, t)
 ∂/∂t[y(t, ξ)]
 
-julia> d2 = deriv(y, t, ξ)
+julia> d2 = ∂(y, t, ξ)
 ∂/∂ξ[∂/∂t[y(t, ξ)]]
 
-julia> d3 = ∂(q, t^2)
+julia> d3 = @∂(q, t^2) # the macro version allows the `t^2` syntax
 ∂/∂t[∂/∂t[q(t)]]
 
 julia> d_expr = deriv(y * q - 2t, t)

--- a/docs/src/guide/derivative.md
+++ b/docs/src/guide/derivative.md
@@ -116,7 +116,7 @@ julia> set_all_derivative_methods(model, FiniteDifference(Forward()))
     this, [`constant_over_collocation`](@ref) should be called on the appropriate variables. 
     For example:
     ```jldoctest collocation; setup = :(using InfiniteOpt; model = InfiniteModel()) 
-    @infinite_parameter(model, t in [0, 1], deriviative_method = OrthogonalCollocation(3))
+    @infinite_parameter(model, t in [0, 1], derivative_method = OrthogonalCollocation(3))
     @variable(model, y_state, Infinite(t))
     @variable(model, y_control, Infinite(t))
     @constraint(model, ∂(y_state, t) == y_state^2)
@@ -124,7 +124,7 @@ julia> set_all_derivative_methods(model, FiniteDifference(Forward()))
     constant_over_collocation(y_control, t)
 
     # output
-    
+
     ```
     where we use `constant_over_collocation` to hold `y_control` constant over each finite 
     element (i.e., constant for each internal collocation point). 

--- a/docs/src/guide/derivative.md
+++ b/docs/src/guide/derivative.md
@@ -37,35 +37,35 @@ over finite elements using 3 nodes. We'll come back to this just a little furthe
 below to more fully describe the various methods we can use. 
 
 First, let's discuss how to define derivatives in `InfiniteOpt.jl`. Principally, 
-this is accomplished via [`@deriv`](@ref) which will operate on a particular 
+this is accomplished via [`deriv`](@ref) which will operate on a particular 
 `InfiniteOpt` expression (containing parameters, variables, and/or measures) with 
 respect to infinite parameters specified with their associated orders. Behind the 
 scenes all the appropriate calculus will be applied, creating derivative variables 
 as needed. For example, we can define the following:
 ```jldoctest deriv_basic 
-julia> d1 = @deriv(y, t)
+julia> d1 = deriv(y, t)
 ∂/∂t[y(t, ξ)]
 
-julia> d2 = @deriv(y, t, ξ)
+julia> d2 = deriv(y, t, ξ)
 ∂/∂ξ[∂/∂t[y(t, ξ)]]
 
-julia> d3 = @∂(q, t^2)
+julia> d3 = ∂(q, t^2)
 ∂/∂t[∂/∂t[q(t)]]
 
-julia> d_expr = @deriv(y * q - 2t, t)
+julia> d_expr = deriv(y * q - 2t, t)
 ∂/∂t[y(t, ξ)]*q(t) + y(t, ξ)*∂/∂t[q(t)] - 2
 ```
 Thus, we can define derivatives in a variety of forms according to the problem at 
 hand. The last example even shows how the product rule is correctly applied. 
 
 !!! note 
-    For convenience in making more compact code we provide [`∂`](@ref) and 
-    [`@∂`](@ref) as wrappers for [`deriv`](@ref) and [`@deriv`](@ref), respectively.
+    For convenience in making more compact code we provide [`∂`](@ref) 
+    as a wrapper for [`deriv`](@ref).
 
 Also, notice that the appropriate analytic calculus is applied to infinite 
 parameters. For example, we could also compute:
 ```jldoctest deriv_basic 
-julia> @deriv(3t^2 - 2t, t)
+julia> deriv(3t^2 - 2t, t)
 6 t - 2
 ```
 
@@ -108,6 +108,23 @@ to specify/modify the derivative method used. More conveniently, we can call
 julia> set_all_derivative_methods(model, FiniteDifference(Forward()))
 
 ```
+
+!!! note
+    When [`OrthogonalCollocation`](@ref) is used, additional degrees of freedom can be 
+    artificially introduced to infinite variables that share the same infinite parameter. 
+    For instance, this occurs with control variables in optimal control problems. To address 
+    this, [`constant_over_collocation`](@ref) should be called on the appropriate variables. 
+    For example:
+    ```jldoctest collocation; setup = :(using InfiniteOpt; model = InfiniteModel()) 
+    @infinite_parameter(model, t in [0, 1], deriviative_method = OrthogonalCollocation(3))
+    @variable(model, y_state, Infinite(t))
+    @variable(model, y_control, Infinite(t))
+    @constraint(model, ∂(y_state, t) == y_state^2)
+    @constraint(model, y_state(0) == 0)
+    constant_over_collocation(y_control, t)
+    ```
+    where we use `constant_over_collocation` to hold `y_control` constant over each finite 
+    element (i.e., constant for each internal collocation point). 
 
 !!! warning
     `InfiniteOpt` does not ensure proper boundary conditions are provided by the 
@@ -387,6 +404,11 @@ the corresponding derivative will be free variable. For more information on
 orthogonal collocation over finite elements, this 
 [page](http://apmonitor.com/do/index.php/Main/OrthogonalCollocation) provides a 
 good reference.
+
+The addition of internal collocation supports by `OrthogonalCollocation` will increase 
+the degrees of freedom for infinite variables that are not used by derivatives (e.g., 
+control variables). To prevent this, we use [`constant_over_collocation`](@ref) on any 
+such infinite variables to hold them constant over internal collocation nodes. 
 
 Other methods can be employed via user-defined extensions. Please visit our 
 Extensions page for more information.

--- a/docs/src/guide/derivative.md
+++ b/docs/src/guide/derivative.md
@@ -122,6 +122,9 @@ julia> set_all_derivative_methods(model, FiniteDifference(Forward()))
     @constraint(model, ∂(y_state, t) == y_state^2)
     @constraint(model, y_state(0) == 0)
     constant_over_collocation(y_control, t)
+
+    # output
+    
     ```
     where we use `constant_over_collocation` to hold `y_control` constant over each finite 
     element (i.e., constant for each internal collocation point). 

--- a/docs/src/guide/derivative.md
+++ b/docs/src/guide/derivative.md
@@ -113,8 +113,8 @@ julia> set_all_derivative_methods(model, FiniteDifference(Forward()))
     When [`OrthogonalCollocation`](@ref) is used, additional degrees of freedom can be 
     artificially introduced to infinite variables that share the same infinite parameter. 
     For instance, this occurs with control variables in optimal control problems. To address 
-    this, [`constant_over_collocation`](@ref) should be called on the appropriate variables. 
-    For example:
+    this, [`constant_over_collocation`](@ref constant_over_collocation(::InfiniteVariableRef, ::GeneralVariableRef)) 
+    should be called on the appropriate variables. For example:
     ```jldoctest collocation; setup = :(using InfiniteOpt; model = InfiniteModel()) 
     @infinite_parameter(model, t in [0, 1], derivative_method = OrthogonalCollocation(3))
     @variable(model, y_state, Infinite(t))

--- a/docs/src/guide/measure.md
+++ b/docs/src/guide/measure.md
@@ -190,7 +190,7 @@ The arguments of [`DiscreteMeasureData`](@ref) are parameter, coefficients, and
 supports. The default weight function is ``w(\tau) = 1`` for 
 any ``\tau``, which can be overwritten by the keyword argument `weight_function`. 
 The `weight_function` should take a function that returns a number for any 
-value that is well defined for the integrated infinite parameter. The data type 
+value that is well-defined for the integrated infinite parameter. The data type 
 is [`DiscreteMeasureData`](@ref), which is a subtype of the abstract data type 
 [`AbstractMeasureData`](@ref).
 

--- a/docs/src/manual/expression.md
+++ b/docs/src/manual/expression.md
@@ -154,6 +154,7 @@ JuMP.is_integer(::GeneralVariableRef)
 JuMP.set_integer(::GeneralVariableRef)
 JuMP.IntegerRef(::GeneralVariableRef)
 JuMP.unset_integer(::GeneralVariableRef)
+constant_over_collocation(::GeneralVariableRef, ::GeneralVariableRef)
 ```
 
 ## Developer Internal Methods

--- a/docs/src/manual/transcribe.md
+++ b/docs/src/manual/transcribe.md
@@ -17,6 +17,7 @@ InfiniteOpt.TranscriptionOpt.transcribe_measures!
 InfiniteOpt.TranscriptionOpt.transcribe_objective!
 InfiniteOpt.TranscriptionOpt.transcribe_constraints!
 InfiniteOpt.TranscriptionOpt.transcribe_derivative_evaluations!
+InfiniteOpt.TranscriptionOpt.transcribe_variable_collocation_restictions!
 InfiniteOpt.TranscriptionOpt.build_transcription_model!
 InfiniteOpt.add_point_variable(::JuMP.Model,::InfiniteOpt.GeneralVariableRef,::Vector{Float64},::Val{:TransData})
 InfiniteOpt.add_semi_infinite_variable(::JuMP.Model,::InfiniteOpt.SemiInfiniteVariable,::Val{:TransData})

--- a/docs/src/manual/variable.md
+++ b/docs/src/manual/variable.md
@@ -144,6 +144,7 @@ JuMP.delete(::InfiniteModel, ::DecisionVariableRef)
 ```@docs
 set_start_value_function(::InfiniteVariableRef, ::Union{Real, Function})
 reset_start_value_function(::InfiniteVariableRef)
+constant_over_collocation(::InfiniteVariableRef, ::GeneralVariableRef)
 ```
 
 ### Semi-Infinite

--- a/docs/src/tutorials/quick_start.md
+++ b/docs/src/tutorials/quick_start.md
@@ -229,7 +229,7 @@ c4 : 𝔼{ξ}[y[1](ξ) + y[2](ξ) + y[3](ξ) + y[4](ξ)] - ϵ ≤ 0
 Notice we are able to invoke an expectation simply by calling [`expect`](@ref).
 
 Finally, to address any unwanted degrees of freedom introduced by internal collocation 
-nodes with [`OrthogonalCollocation`](@ref). We should call [`constant_over_collocation`](@ref) 
+nodes with [`OrthogonalCollocation`](@ref). We should call [`constant_over_collocation`](@ref constant_over_collocation(::InfiniteVariableRef, ::GeneralVariableRef)) 
 on any control variables:
 ```jldoctest quick
 julia> constant_over_collocation.(u, t);

--- a/docs/src/tutorials/quick_start.md
+++ b/docs/src/tutorials/quick_start.md
@@ -241,13 +241,13 @@ That's it, now we have our problem defined in `InfiniteOpt`!
 ## Solution & Queries
 ### Optimize 
 Now that our model is defined, let's optimize it via [`optimize!`](@ref):
-```julia-repl
+```jldoctest quick; setup = :(set_optimizer_attribute(model, "print_level", 0))
 julia> optimize!(model)
 
 ```
 We can check the solution status via 
 [`termination_status`](@ref JuMP.termination_status(::InfiniteModel)):
-```jldoctest quick; setup = :(set_optimizer_attribute(model, "print_level", 0); optimize!(model))
+```jldoctest quick
 julia> termination_status(model)
 LOCALLY_SOLVED::TerminationStatusCode = 4
 ```
@@ -273,8 +273,8 @@ julia> u_ts = supports.(u)
 1-dimensional DenseAxisArray{Vector{Tuple},1,...} with index sets:
     Dimension 1, 1:2
 And data, a 2-element Vector{Vector{Tuple}}:
- [0.0, 0.01910808707516623, 0.018047000516923158, 0.016985913958680085, 0.015924827400437012, 0.014863740842193935, 0.013802654283950862, 0.012741567725707786, 0.011680481167464712, 0.01061939460922164  …  -0.015469961800111056, -0.013841544768520418, -0.012213127736929785, -0.01058471070533914, -0.008956293673748507, -0.007327876642157868, -0.005699459610567232, -0.0040710425789765945, -0.0024426255473859564, -0.0010856113543937583]
- [0.0, 0.012692356649505403, 0.011753972332627835, 0.010815588015750272, 0.009877203698872707, 0.008938819381995143, 0.008000435065117578, 0.007062050748240013, 0.006123666431362448, 0.005185282114484884  …  0.004098637887815126, 0.0036672023206766914, 0.0032357667535382576, 0.0028043311863998237, 0.0023728956192613894, 0.0019414600521229543, 0.0015100244849845202, 0.0010785889178460857, 0.0006471533507076515, 0.00028762371142562293]
+ [(0.0,), (1.0,), (2.0,), (3.0,), (4.0,), (5.0,), (6.0,), (7.0,), (8.0,), (9.0,)  …  (51.0,), (52.0,), (53.0,), (54.0,), (55.0,), (56.0,), (57.0,), (58.0,), (59.0,), (60.0,)]
+ [(0.0,), (1.0,), (2.0,), (3.0,), (4.0,), (5.0,), (6.0,), (7.0,), (8.0,), (9.0,)  …  (51.0,), (52.0,), (53.0,), (54.0,), (55.0,), (56.0,), (57.0,), (58.0,), (59.0,), (60.0,)]
 ```
 Please see the [Results](@ref result_docs) page for more information. 
 

--- a/src/TranscriptionOpt/model.jl
+++ b/src/TranscriptionOpt/model.jl
@@ -907,7 +907,7 @@ function support_index_iterator(
     raw_supps = parameter_supports(model)
     lens = map(i -> length(i), raw_supps)
     # prepare the indices of each support combo
-    # note that the actual supports are afrom 1:length-1 and the placeholders are at the ends
+    # note that the actual supports are from 1:length-1 and the placeholders are at the ends
     return CartesianIndices(ntuple(i -> i in obj_nums ? (1:lens[i]-1) : (lens[i]:lens[i]),
                                    length(raw_supps)))
 end

--- a/src/derivative_evaluations.jl
+++ b/src/derivative_evaluations.jl
@@ -11,6 +11,8 @@ elements to approximate derivatives. The constructor is of the form:
     OrthogonalCollocation(num_nodes::Int, 
                           [quad::AbstractUnivariateMethod = GaussLobatto])
 ```
+Note that if `num_nodes > 2` and the problem contains control variables, then 
+[`constant_over_collocation`](@ref) should probably be used on those variables.
 
 **Fields**
 - `num_nodes::Int`: The number of collocation points (nodes) per finite element.

--- a/src/derivative_evaluations.jl
+++ b/src/derivative_evaluations.jl
@@ -12,7 +12,8 @@ elements to approximate derivatives. The constructor is of the form:
                           [quad::AbstractUnivariateMethod = GaussLobatto])
 ```
 Note that if `num_nodes > 2` and the problem contains control variables, then 
-[`constant_over_collocation`](@ref) should probably be used on those variables.
+[`constant_over_collocation`](@ref constant_over_collocation(::InfiniteVariableRef, ::GeneralVariableRef)) 
+should probably be used on those variables.
 
 **Fields**
 - `num_nodes::Int`: The number of collocation points (nodes) per finite element.

--- a/src/general_variables.jl
+++ b/src/general_variables.jl
@@ -871,7 +871,23 @@ being defined for the underlying `DispatchVariableRef`, otherwise an
 `ArgumentError` is thrown. See the underlying docstrings for more
 information.
 """
-function JuMP.fix(vref::GeneralVariableRef, value::Real;
-                  force::Bool = false)::Nothing
+function JuMP.fix(vref::GeneralVariableRef, value::Real; force::Bool = false)
     return JuMP.fix(dispatch_variable_ref(vref), value, force = force)
+end
+
+
+# Dispatch fallback for constant_over_collocation
+function constant_over_collocation(vref::DispatchVariableRef, pref::GeneralVariableRef)
+    throw(ArgumentError("`constant_over_collocation` not defined for variable reference type " *
+                        "`$(typeof(vref))`."))
+end
+
+"""
+    constant_over_collocation(vref::GeneralVariableRef, pref::GeneralVariableRef)::Nothing
+
+Define `constant_over_collocation` for general variable references. It wraps around the 
+method defined for `InfiniteVariableRef`s.
+"""
+function constant_over_collocation(vref::GeneralVariableRef, pref::GeneralVariableRef)
+    return constant_over_collocation(dispatch_variable_ref(vref), pref)
 end

--- a/src/infinite_variables.jl
+++ b/src/infinite_variables.jl
@@ -5,7 +5,7 @@
 function dispatch_variable_ref(
     model::InfiniteModel,
     index::InfiniteVariableIndex
-    )::InfiniteVariableRef
+    )
     return InfiniteVariableRef(model, index)
 end
 
@@ -13,7 +13,7 @@ end
 function _add_data_object(
     model::InfiniteModel,
     object::VariableData{<:InfiniteVariable}
-    )::InfiniteVariableIndex
+    )
     return MOIUC.add_item(model.infinite_vars, object)
 end
 
@@ -21,14 +21,14 @@ end
 function _data_dictionary(
     model::InfiniteModel, 
     ::Type{InfiniteVariable}
-    )::MOIUC.CleverDict{InfiniteVariableIndex, VariableData{<:InfiniteVariable}}
+    )
     return model.infinite_vars
 end
 
 # Extend _data_dictionary (reference based)
 function _data_dictionary(
     vref::InfiniteVariableRef
-    )::MOIUC.CleverDict{InfiniteVariableIndex, VariableData{<:InfiniteVariable}}
+    )
     return JuMP.owner_model(vref).infinite_vars
 end
 
@@ -49,17 +49,17 @@ function _core_variable_object(vref::InfiniteVariableRef)
 end
 
 # Extend _object_numbers
-function _object_numbers(vref::InfiniteVariableRef)::Vector{Int}
+function _object_numbers(vref::InfiniteVariableRef)
     return _core_variable_object(vref).object_nums
 end
 
 # Extend _parameter_numbers
-function _parameter_numbers(vref::InfiniteVariableRef)::Vector{Int}
+function _parameter_numbers(vref::InfiniteVariableRef)
     return _core_variable_object(vref).parameter_nums
 end
 
 # Define getter function for var.is_vector_start
-function _is_vector_start(vref::InfiniteVariableRef)::Bool
+function _is_vector_start(vref::InfiniteVariableRef)
     return _core_variable_object(vref).is_vector_start
 end
 
@@ -69,7 +69,7 @@ function _adaptive_data_update(
     vref::InfiniteVariableRef, 
     var::V, 
     data::VariableData{V}
-    )::Nothing where {V <: InfiniteVariable}
+    ) where {V <: InfiniteVariable}
     data.variable = var
     return
 end
@@ -79,7 +79,7 @@ function _adaptive_data_update(
     vref::InfiniteVariableRef, 
     var::V1, 
     data::VariableData{V2}
-    )::Nothing  where {V1, V2}
+    )  where {V1, V2}
     new_data = VariableData(var, data.name, data.lower_bound_index,
                             data.upper_bound_index, data.fix_index,
                             data.zero_one_index, data.integrality_index,
@@ -95,7 +95,7 @@ end
 function _set_core_variable_object(
     vref::InfiniteVariableRef,
     var::InfiniteVariable
-    )::Nothing
+    )
     _adaptive_data_update(vref, var, _data_object(vref))
     return
 end
@@ -148,7 +148,7 @@ end
 function _check_tuple_element(
     _error::Function,
     prefs::Vector{IndependentParameterRef}
-    )::Nothing
+    )
     return
 end
 
@@ -156,7 +156,7 @@ end
 function _check_tuple_element(
     _error::Function,
     prefs::Vector{DependentParameterRef}
-    )::Nothing
+    )
     if length(prefs) != _num_parameters(first(prefs))
         _error("Infinite parameter tuple elements cannot depend on a subset ",
                "of dependent parameters.")
@@ -174,7 +174,7 @@ end
 function _check_parameter_tuple(
     _error::Function,
     raw_prefs::Collections.VectorTuple{GeneralVariableRef}
-    )::Nothing
+    )
     allunique(raw_prefs) || _error("Cannot double specify infinite parameter ",
                                    "references.")
     for i in 1:size(raw_prefs, 1)
@@ -214,7 +214,7 @@ function _check_valid_function(
     _error::Function, 
     func::Function, 
     prefs::Collections.VectorTuple
-    )::Nothing 
+    )
     input_format = typeof(Tuple(Vector{Float64}(undef, length(prefs)), prefs))
     if !hasmethod(func, input_format)
         _error("Specified function `$func` must be able to accept a `Float64` " * 
@@ -228,7 +228,7 @@ function _check_and_format_infinite_info(
     _error::Function,
     info::JuMP.VariableInfo{<:Real, <:Real, <:Real, F},
     prefs::Collections.VectorTuple
-    )::Tuple{JuMP.VariableInfo{Float64, Float64, Float64, F}, Bool} where {F <: Function}
+    ) where {F <: Function}
     # check the function properties
     _check_valid_function(_error, info.start, prefs)
     # make the info and return
@@ -295,7 +295,7 @@ end
 function _check_parameters_valid(
     model::InfiniteModel,
     prefs::Collections.VectorTuple
-    )::Nothing
+    )
     for pref in prefs
         JuMP.check_belongs_to_model(pref, model)
     end
@@ -306,7 +306,7 @@ end
 function _update_param_var_mapping(
     vref::InfiniteVariableRef,
     prefs::Collections.VectorTuple
-    )::Nothing
+    )
     for pref in prefs
         dependency_list = _infinite_variable_dependencies(pref)
         if !(JuMP.index(vref) in dependency_list)
@@ -343,7 +343,7 @@ function JuMP.add_variable(
     model::InfiniteModel,
     v::InfiniteVariable,
     name::String = ""
-    )::GeneralVariableRef 
+    )
     _check_parameters_valid(model, v.parameter_refs)
     data_object = VariableData(v, name)
     vindex = _add_data_object(model, data_object)
@@ -363,7 +363,7 @@ end
 function _restrict_infinite_variable(
     ivref::GeneralVariableRef, 
     vt::Collections.VectorTuple{<:Real}
-    )::GeneralVariableRef
+    )
     info = JuMP.VariableInfo(false, NaN, false, NaN, false, NaN, false, NaN, 
                              false, false)
     new_var = JuMP.build_variable(error, info, Point(ivref, vt))
@@ -375,7 +375,7 @@ end
 function _restrict_infinite_variable(
     ivref::GeneralVariableRef, 
     vt::Collections.VectorTuple{<:GeneralVariableRef}
-    )::GeneralVariableRef
+    )
     if parameter_list(ivref) != vt.values
         error("Unrecognized syntax for infinite variable restriction.")
     end
@@ -390,7 +390,7 @@ end
 function _restrict_infinite_variable(
     ivref::GeneralVariableRef, 
     vt::Collections.VectorTuple
-    )::GeneralVariableRef
+    )
     info = JuMP.VariableInfo(false, NaN, false, NaN, false, NaN, false, NaN, 
                              false, false)
     new_var = JuMP.build_variable(error, info, SemiInfinite(ivref, vt))
@@ -430,7 +430,7 @@ julia> y(0, [0, 0])
 y(0, [0, 0])
 ```
 """
-function restrict(ivref::GeneralVariableRef, supps...)::GeneralVariableRef
+function restrict(ivref::GeneralVariableRef, supps...)
     idx_type = _index_type(ivref)
     if idx_type != InfiniteVariableIndex && idx_type != DerivativeIndex
         error("The `vref(values..)` restriction syntax is only valid for ",
@@ -444,7 +444,7 @@ function _functional_reference_call(
     ivref::GeneralVariableRef, 
     ::Union{Type{InfiniteVariableIndex}, Type{DerivativeIndex}}, 
     supps...
-    )::GeneralVariableRef
+    )
     return _restrict_infinite_variable(ivref, Collections.VectorTuple(supps))
 end
 
@@ -454,21 +454,21 @@ end
 # Extend _semi_infinite_variable_dependencies
 function _semi_infinite_variable_dependencies(
     vref::Union{InfiniteVariableRef, DerivativeRef}
-    )::Vector{SemiInfiniteVariableIndex}
+    )
     return _data_object(vref).semi_infinite_var_indices
 end
 
 # Extend _point_variable_dependencies
 function _point_variable_dependencies(
     vref::Union{InfiniteVariableRef, DerivativeRef}
-    )::Vector{PointVariableIndex}
+    )
     return _data_object(vref).point_var_indices
 end
 
 # Extend _derivative_dependencies
 function _derivative_dependencies(
     vref::Union{InfiniteVariableRef, DerivativeRef}
-    )::Vector{DerivativeIndex}
+    )
     return _data_object(vref).derivative_indices
 end
 
@@ -485,7 +485,7 @@ false
 """
 function used_by_semi_infinite_variable(
     vref::Union{InfiniteVariableRef, DerivativeRef}
-    )::Bool
+    )
     return !isempty(_semi_infinite_variable_dependencies(vref))
 end
 
@@ -502,7 +502,7 @@ false
 """
 function used_by_point_variable(
     vref::Union{InfiniteVariableRef, DerivativeRef}
-    )::Bool
+    )
     return !isempty(_point_variable_dependencies(vref))
 end
 
@@ -517,7 +517,7 @@ julia> used_by_derivative(vref)
 true
 ```
 """
-function used_by_derivative(vref::Union{InfiniteVariableRef, DerivativeRef})::Bool
+function used_by_derivative(vref::Union{InfiniteVariableRef, DerivativeRef})
     return !isempty(_derivative_dependencies(vref))
 end
 
@@ -532,7 +532,7 @@ julia> is_used(vref)
 false
 ```
 """
-function is_used(vref::Union{InfiniteVariableRef, DerivativeRef})::Bool
+function is_used(vref::Union{InfiniteVariableRef, DerivativeRef})
     if used_by_measure(vref) || used_by_constraint(vref)
         return true
     end
@@ -596,14 +596,14 @@ Return a vector of the parameter references that `vref` depends on. This is
 primarily an internal method where [`parameter_refs`](@ref parameter_refs(vref::InfiniteVariableRef))
 is intended as the preferred user function.
 """
-function parameter_list(vref::InfiniteVariableRef)::Vector{GeneralVariableRef}
+function parameter_list(vref::InfiniteVariableRef)
     return raw_parameter_refs(vref).values
 end
 
 # get parameter list from raw VectorTuple
 function parameter_list(
     prefs::Collections.VectorTuple{GeneralVariableRef}
-    )::Vector{GeneralVariableRef}
+    )
     return prefs.values
 end
 
@@ -613,15 +613,15 @@ end
 ## format infinite info 
 # Good to go
 function _format_infinite_info(
-    info::I
-    )::I where {I <: JuMP.VariableInfo{Float64, Float64, Float64, <:Function}}
+    info::JuMP.VariableInfo{Float64, Float64, Float64, <:Function}
+    )
     return info
 end
 
 # Convert as needed 
 function _format_infinite_info(
     info::JuMP.VariableInfo{V, W, T, F}
-    )::JuMP.VariableInfo{Float64, Float64, Float64, F} where {V, W, T, F <: Function}
+    ) where {V, W, T, F <: Function}
     return JuMP.VariableInfo(info.has_lb, convert(Float64, info.lower_bound), 
                              info.has_ub, convert(Float64, info.upper_bound), 
                              info.has_fix, convert(Float64, info.fixed_value),
@@ -633,7 +633,7 @@ end
 function _update_variable_info(
     vref::InfiniteVariableRef,
     info::JuMP.VariableInfo
-    )::Nothing
+    )
     prefs = raw_parameter_refs(vref)
     param_nums = _parameter_numbers(vref)
     obj_nums = _object_numbers(vref)
@@ -674,7 +674,7 @@ my_start_func
 """
 function start_value_function(
     vref::Union{InfiniteVariableRef, DerivativeRef}
-    )::Union{Nothing, Function}
+    )
     if _variable_info(vref).has_start
         return _variable_info(vref).start
     else
@@ -702,7 +702,7 @@ julia> set_start_value_function(vref, my_func) # each value will be made via my_
 function set_start_value_function(
     vref::InfiniteVariableRef,
     start::Union{Real, Function}
-    )::Nothing
+    )
     info = _variable_info(vref)
     set_optimizer_model_ready(JuMP.owner_model(vref), false)
     prefs = raw_parameter_refs(vref)
@@ -729,7 +729,7 @@ this is triggered by deleting an infinite parameter that `vref` depends on.
 julia> reset_start_value_function(vref)
 ```
 """
-function reset_start_value_function(vref::InfiniteVariableRef)::Nothing
+function reset_start_value_function(vref::InfiniteVariableRef)
     info = _variable_info(vref)
     set_optimizer_model_ready(JuMP.owner_model(vref), false)
     start_func = (s::Vector{<:Real}) -> NaN
@@ -746,18 +746,65 @@ function reset_start_value_function(vref::InfiniteVariableRef)::Nothing
 end
 
 ################################################################################
+#                           PIECEWISE RESTRICTIONS
+################################################################################
+"""
+    constant_over_collocation(vref::InfiniteVariableRef, pref::GeneralVariableRef)::Nothing
+
+Adds constraints such that `vref` is constant over internal collocation points 
+generated within finite elements for `pref`. This is prinicipally useful for 
+manipulated variables in control problems that use [`OrthogonalCollocation`](@ref).
+Errors if `pref` is not a single independent infinite parameter and/or it is not 
+used by `vref`.
+
+**Example**
+```julia
+@infinite_parameter(model, t in [0, 1], deriviative_method = OrthogonalCollocation(3))
+@variable(model, y_state, Infinite(t))
+@variable(model, y_control, Infinite(t))
+@constraint(model, ∂(y_state, t) == y_state^2)
+@constraint(model, y_state(0) == 0)
+constant_over_collocation(y_control, t)
+```
+"""
+function constant_over_collocation(vref::InfiniteVariableRef, pref::GeneralVariableRef)
+    if pref.index_type != IndependentParameterIndex
+        error("Cannot set piecewise constant variables with respect to " *
+              "dependent array infinite parameters.")
+    elseif !(pref in raw_parameter_refs(vref))
+        error("Variable $vref does not depend on infinite parameter $pref.")
+    end
+    pidx = JuMP.index(pref)
+    dict = JuMP.owner_model(vref).piecewise_vars
+    if haskey(dict, pidx)
+        push!(dict[pidx], JuMP.index(vref))
+    else
+        dict[pidx] = Set(JuMP.index(vref))
+    end
+    return
+end
+
+################################################################################
 #                                 DELETION
 ################################################################################
 # Extend _delete_variable_dependencies (for use with JuMP.delete)
-function _delete_variable_dependencies(vref::InfiniteVariableRef)::Nothing
+function _delete_variable_dependencies(vref::InfiniteVariableRef)
     # remove variable info constraints associated with vref
     _delete_info_constraints(vref)
-    # update parameter mapping
+    # update parameter mapping and remove piecewise settings
     all_prefs = parameter_list(vref)
-    for pref in all_prefs
-        filter!(e -> e != JuMP.index(vref), _infinite_variable_dependencies(pref))
-    end
     model = JuMP.owner_model(vref)
+    vidx = JuMP.index(vref)
+    for pref in all_prefs
+        filter!(e -> e != vidx, _infinite_variable_dependencies(pref))
+        pidx = JuMP.index(pref)
+        if haskey(model.piecewise_vars, pidx)
+            filter!(i -> i != vidx, model.piecewise_vars[pidx])
+            if isempty(model.piecewise_vars[pidx])
+                delete!(model.piecewise_vars, pidx)
+            end
+        end
+    end
     # delete associated point variables and mapping
     for index in _point_variable_dependencies(vref)
         JuMP.delete(model, dispatch_variable_ref(model, index))

--- a/test/deletion.jl
+++ b/test/deletion.jl
@@ -558,6 +558,8 @@ end
     @constraint(m, con1, x + y + par <= 0)
     con2 = add_constraint(m, ScalarConstraint(y, MOI.LessThan(0.)))
     @constraint(m, con3, [x, y] in MOI.Zeros(2))
+    constant_over_collocation(x, par)
+    constant_over_collocation(y, par)
     # test deletion of x
     @test isa(delete(m, x), Nothing)
     @test num_constraints(m) == 4
@@ -571,6 +573,7 @@ end
     @test !is_valid(m, d1)
     @test !haskey(InfiniteOpt._data_dictionary(m, InfiniteVariable), JuMP.index(x))
     @test !is_valid(m, con3)
+    @test m.piecewise_vars[index(par)] == Set(index(y))
     # test deletion of y
     @test isa(delete(m, y), Nothing)
     @test num_constraints(m) == 2
@@ -583,6 +586,7 @@ end
     @test InfiniteOpt._object_numbers(con2) == []
     @test InfiniteOpt._infinite_variable_dependencies(par) == []
     @test !haskey(InfiniteOpt._data_dictionary(m, InfiniteVariable), JuMP.index(y))
+    @test isempty(m.piecewise_vars)
     # test errors
     @test_throws AssertionError delete(m, x)
     @test_throws AssertionError delete(m, y)

--- a/test/general_variables.jl
+++ b/test/general_variables.jl
@@ -481,6 +481,7 @@ end
     idx = TestIndex(1)
     dvref = TestVariableRef(m, idx)
     gvref = GeneralVariableRef(m, 1, TestIndex)
+    pref = GeneralVariableRef(m, -1, IndependentParameterIndex)
     # test 1 argument methods 
     for f in (:has_lower_bound, :has_upper_bound, :is_fixed, :is_binary, 
               :is_integer, :lower_bound, :upper_bound, :fix_value, :start_value,
@@ -502,6 +503,14 @@ end
     # test JuMP.fix (GeneralVariableRef)
     @testset "JuMP.fix (GeneralVariableRef)" begin
         @test_throws ArgumentError fix(gvref, 42, force = true)
+    end
+    # test constant_over_collocation (Fallback)
+    @testset "constant_over_collocation (Fallback)" begin
+        @test_throws ArgumentError constant_over_collocation(dvref, pref)
+    end
+    # test constant_over_collocation (GeneralVariableRef)
+    @testset "constant_over_collocation (GeneralVariableRef)" begin
+        @test_throws ArgumentError constant_over_collocation(gvref, pref)
     end
     # test set_start_value_function (Fallback)
     @testset "set_start_value_function (Fallback)" begin

--- a/test/infinite_variables.jl
+++ b/test/infinite_variables.jl
@@ -577,6 +577,26 @@ end
     # Note: the rest of the cases are tested with point variables and semi-infinite variables
 end
 
+# test collocation restrictions
+@testset "constant_over_collocation" begin 
+    # setup the info 
+    m = InfiniteModel()
+    @infinite_parameter(m, t in [0, 1])
+    @infinite_parameter(m, x[1:2] in [0, 1], independent = true)
+    @infinite_parameter(m, xi[1:2] in [0, 1])
+    @variable(m, y, Infinite(t, x, xi))
+    @variable(m, q, Infinite(t))
+    # test errors 
+    @test_throws ErrorException constant_over_collocation(y, xi[1])
+    @test_throws ErrorException constant_over_collocation(q, x[1])
+    # test normal 
+    @test constant_over_collocation(y, t) isa Nothing
+    @test constant_over_collocation(q, t) isa Nothing
+    @test m.piecewise_vars[index(t)] == Set([index(y), index(q)])
+    @test constant_over_collocation(y, x[2]) isa Nothing
+    @test m.piecewise_vars[index(x[2])] == Set(index(y))
+end
+
 # Test variable(s) constrained on creation 
 @testset "Creation Constraints" begin 
     # initialize model and stuff


### PR DESCRIPTION
To resolve the degrees of freedom encountered by control variables with orthogonal collocation, this introduces `constant_over_collocation` to have control variables held to one a single degree of freedom per finite element. Closes #216.
