### PR TITLE
Fix SigFig Bug

### DIFF
--- a/docs/src/guide/constraint.md
+++ b/docs/src/guide/constraint.md
@@ -242,7 +242,7 @@ argument. This includes a wealth of constraint types including:
 For example, we could define the following semi-definite constraint:
 ```jldoctest constrs
 julia> @constraint(model, [yb 2yb; 3yb 4yb] >= ones(2, 2), PSDCone())
-[yb(t) - 1    2 yb(t) - 1;
+[yb(t) - 1    2 yb(t) - 1
  3 yb(t) - 1  4 yb(t) - 1] ∈ PSDCone(), ∀ t ∈ [0, 10]
 ```
 See [`JuMP`'s constraint documentation](https://jump.dev/JuMP.jl/v1/manual/constraints/) 

--- a/docs/src/guide/derivative.md
+++ b/docs/src/guide/derivative.md
@@ -1,6 +1,6 @@
 ```@meta
 DocTestFilters = [r"≥|>=", r" == | = ", r" ∈ | in ", r" for all | ∀ ", r"d|∂", 
-                  r"integral|∫", r".*scalar_parameters.jl:783"]
+                  r"integral|∫", r".*scalar_parameters.jl:790"]
 ```
 
 # [Derivative Operators](@id deriv_docs)
@@ -502,7 +502,7 @@ julia> derivative_constraints(d1)
 
 julia> add_supports(t, 0.2)
 ┌ Warning: Support/method changes will invalidate existing derivative evaluation constraints that have been added to the InfiniteModel. Thus, these are being deleted.
-└ @ InfiniteOpt ~/work/infiniteopt/InfiniteOpt.jl/src/scalar_parameters.jl:783
+└ @ InfiniteOpt ~/work/infiniteopt/InfiniteOpt.jl/src/scalar_parameters.jl:790
 
 julia> has_derivative_constraints(d1)
 false

--- a/docs/src/manual/domains.md
+++ b/docs/src/manual/domains.md
@@ -22,6 +22,7 @@ JuMP.set_lower_bound(::AbstractInfiniteDomain, ::Real)
 JuMP.has_upper_bound(::AbstractInfiniteDomain)
 JuMP.upper_bound(::AbstractInfiniteDomain)
 JuMP.set_upper_bound(::AbstractInfiniteDomain, ::Real)
+InfiniteOpt.round_domain
 ```
 
 ## Support Point Labels

--- a/src/array_parameters.jl
+++ b/src/array_parameters.jl
@@ -223,7 +223,7 @@ function _build_parameters(
     end
     # process the infinite domain
     domain = _make_array_domain(_error, domains, orig_inds)
-    domain = _round_domain(domain, sig_digits)
+    domain = round_domain(domain, sig_digits)
     # we have supports
     if !isempty(supports)
         supp_dict = _process_supports(_error, supports, domain, sig_digits)

--- a/src/infinite_domains.jl
+++ b/src/infinite_domains.jl
@@ -36,14 +36,14 @@ that has bounds.
 round_domain(domain::AbstractInfiniteDomain, sig_digits::Int) = domain
 
 # IntervalDomain
-function _round_domain(domain::IntervalDomain, sig_digits::Int)
+function round_domain(domain::IntervalDomain, sig_digits::Int)
     lb = round(domain.lower_bound, sigdigits = sig_digits)
     ub = round(domain.upper_bound, sigdigits = sig_digits)
     return IntervalDomain(lb, ub)
 end
 
 # CollectionDomain
-function _round_domain(domain::CollectionDomain, sig_digits::Int)
+function round_domain(domain::CollectionDomain, sig_digits::Int)
     return CollectionDomain([_round_domain(d, sig_digits) for d in domain.domains])
 end
 

--- a/src/infinite_domains.jl
+++ b/src/infinite_domains.jl
@@ -25,20 +25,21 @@ Base.length(s::InfiniteScalarDomain) = 1
 ################################################################################
 #                          ENFORCE SIG FIGS ON DOMAINS
 ################################################################################
-## Round domains such that generated supports are always inside them
-# Interval domain
+"""
+    round_domain(domain::AbstractInfiniteDomain, sig_digits::Int)
+
+Return a rounded domain of `domain` where its bounds use a number of 
+significant digits equal to `sig_digs`. This is intended as an internal 
+method and should be extended by those adding a new kind of infinite domain 
+that has bounds. 
+"""
+round_domain(domain::AbstractInfiniteDomain, sig_digits::Int) = domain
+
+# IntervalDomain
 function _round_domain(domain::IntervalDomain, sig_digits::Int)
     lb = round(domain.lower_bound, sigdigits = sig_digits)
     ub = round(domain.upper_bound, sigdigits = sig_digits)
     return IntervalDomain(lb, ub)
-end
-
-# Distribution domain
-function _round_domain(
-    domain::Union{UniDistributionDomain, MultiDistributionDomain}, 
-    sig_digits::Int
-    )
-    return domain
 end
 
 # CollectionDomain

--- a/src/infinite_domains.jl
+++ b/src/infinite_domains.jl
@@ -44,7 +44,7 @@ end
 
 # CollectionDomain
 function round_domain(domain::CollectionDomain, sig_digits::Int)
-    return CollectionDomain([_round_domain(d, sig_digits) for d in domain.domains])
+    return CollectionDomain([round_domain(d, sig_digits) for d in domain.domains])
 end
 
 ################################################################################

--- a/src/infinite_domains.jl
+++ b/src/infinite_domains.jl
@@ -11,24 +11,49 @@ function collection_domains(domain::AbstractInfiniteDomain)
     type = typeof(domain)
     error("`collection_domains` not defined for infinite domain of type $type.")
 end
-function collection_domains(domain::CollectionDomain{S}
-                         )::Vector{S} where {S <: InfiniteScalarDomain}
+function collection_domains(domain::CollectionDomain)
     return domain.domains
 end
 
 ################################################################################
 #                               BASIC EXTENSIONS
 ################################################################################
-Base.length(s::CollectionDomain)::Int = length(collection_domains(s))
-Base.length(s::MultiDistributionDomain)::Int = length(s.distribution)
-Base.length(s::InfiniteScalarDomain)::Int = 1
+Base.length(s::CollectionDomain) = length(collection_domains(s))
+Base.length(s::MultiDistributionDomain) = length(s.distribution)
+Base.length(s::InfiniteScalarDomain) = 1
+
+################################################################################
+#                          ENFORCE SIG FIGS ON DOMAINS
+################################################################################
+## Round domains such that generated supports are always inside them
+# Interval domain
+function _round_domain(domain::IntervalDomain, sig_digits::Int)
+    lb = round(domain.lower_bound, sigdigits = sig_digits)
+    ub = round(domain.upper_bound, sigdigits = sig_digits)
+    return IntervalDomain(lb, ub)
+end
+
+# Distribution domain
+function _round_domain(
+    domain::Union{UniDistributionDomain, MultiDistributionDomain}, 
+    sig_digits::Int
+    )
+    return domain
+end
+
+# CollectionDomain
+function _round_domain(domain::CollectionDomain, sig_digits::Int)
+    return CollectionDomain([_round_domain(d, sig_digits) for d in domain.domains])
+end
 
 ################################################################################
 #                           SUPPORT VALIDITY METHODS
 ################################################################################
 """
-    supports_in_domain(supports::Union{Real, Vector{<:Real}, Array{<:Real, 2}},
-                    domain::AbstractInfiniteDomain)::Bool
+    supports_in_domain(
+        supports::Union{Real, Vector{<:Real}, Array{<:Real, 2}},
+        domain::AbstractInfiniteDomain
+        )::Bool
 
 Used to check if `supports` are in the domain of `domain`. Returns `true` if
 `supports` are in domain of `domain` and returns `false` otherwise.
@@ -40,8 +65,10 @@ that an error won't be thrown.
 function supports_in_domain end
 
 # IntervalDomain
-function supports_in_domain(supports::Union{Real, Vector{<:Real}},
-                         domain::IntervalDomain)::Bool
+function supports_in_domain(
+    supports::Union{Real, Vector{<:Real}},
+    domain::IntervalDomain
+    )
     min_support = minimum(supports)
     max_support = maximum(supports)
     if min_support < JuMP.lower_bound(domain) || max_support > JuMP.upper_bound(domain)
@@ -51,8 +78,10 @@ function supports_in_domain(supports::Union{Real, Vector{<:Real}},
 end
 
 # UnivariateDistribution domain
-function supports_in_domain(supports::Union{Real, Vector{<:Real}},
-                         domain::UniDistributionDomain)::Bool
+function supports_in_domain(
+    supports::Union{Real, Vector{<:Real}},
+    domain::UniDistributionDomain
+    )
     return all(Distributions.insupport(domain.distribution, supports))
 end
 
@@ -60,7 +89,7 @@ end
 function supports_in_domain(
     supports::Array{<:Real},
     domain::MultiDistributionDomain{<:Distributions.MultivariateDistribution{S}}
-    )::Bool where {S <: Distributions.ValueSupport}
+    ) where {S <: Distributions.ValueSupport}
     if length(domain.distribution) != size(supports, 1)
         error("Support dimensions does not match distribution dimensions.")
     end
@@ -68,7 +97,7 @@ function supports_in_domain(
 end
 
 # CollectionDomain
-function supports_in_domain(supports::Array{<:Real, 2}, domain::CollectionDomain)::Bool
+function supports_in_domain(supports::Array{<:Real, 2}, domain::CollectionDomain)
     domains = collection_domains(domain)
     if length(domains) != size(supports, 1)
         error("Support dimensions does not match CollectionDomain dimensions.")
@@ -82,7 +111,7 @@ function supports_in_domain(supports::Array{<:Real, 2}, domain::CollectionDomain
 end
 
 # Fallback
-function supports_in_domain(supports, domain::AbstractInfiniteDomain)::Bool
+function supports_in_domain(supports, domain::AbstractInfiniteDomain)
     return true
 end
 
@@ -104,18 +133,18 @@ julia> has_lower_bound(domain)
 true
 ```
 """
-function JuMP.has_lower_bound(domain::AbstractInfiniteDomain)::Bool # fallback
+function JuMP.has_lower_bound(domain::AbstractInfiniteDomain) # fallback
     return false
 end
 
 # IntervalDomain
-JuMP.has_lower_bound(domain::IntervalDomain)::Bool = true
+JuMP.has_lower_bound(domain::IntervalDomain) = true
 
 # DistributionDomain (Univariate)
-JuMP.has_lower_bound(domain::UniDistributionDomain)::Bool = true
+JuMP.has_lower_bound(domain::UniDistributionDomain) = true
 
 # CollectionDomain
-function JuMP.has_lower_bound(domain::CollectionDomain)::Bool
+function JuMP.has_lower_bound(domain::CollectionDomain)
     for s in collection_domains(domain)
         if !JuMP.has_lower_bound(s)
             return false
@@ -146,15 +175,15 @@ function JuMP.lower_bound(domain::AbstractInfiniteDomain) # fallback
 end
 
 # IntervalDomain
-JuMP.lower_bound(domain::IntervalDomain)::Float64 = domain.lower_bound
+JuMP.lower_bound(domain::IntervalDomain) = domain.lower_bound
 
 # DistributionDomain (Univariate)
-function JuMP.lower_bound(domain::UniDistributionDomain)::Real
+function JuMP.lower_bound(domain::UniDistributionDomain)
     return minimum(domain.distribution)
 end
 
 # CollectionDomain
-function JuMP.lower_bound(domain::CollectionDomain)::Vector{<:Real}
+function JuMP.lower_bound(domain::CollectionDomain)
     return [JuMP.lower_bound(i) for i in collection_domains(domain)]
 end
 
@@ -174,27 +203,30 @@ julia> set_lower_bound(domain, 0.5)
 [0.5, 1]
 ```
 """
-function JuMP.set_lower_bound(domain::AbstractInfiniteDomain,
-                              lower::Union{Real, Vector{<:Real}}) # fallback
+function JuMP.set_lower_bound(
+    domain::AbstractInfiniteDomain,
+    lower::Union{Real, Vector{<:Real}}
+    ) # fallback
     type = typeof(domain)
     error("`JuMP.set_lower_bound` not defined for infinite domain of type $type.")
 end
 
 # IntervalDomain
-function JuMP.set_lower_bound(domain::IntervalDomain, lower::Real)::IntervalDomain
+function JuMP.set_lower_bound(domain::IntervalDomain, lower::Real)
     return IntervalDomain(lower, domain.upper_bound)
 end
 
 # DistributionDomain
-function JuMP.set_lower_bound(domain::Union{UniDistributionDomain,
-                                         MultiDistributionDomain},
-                              lower::Union{Real, Vector{<:Real}})
+function JuMP.set_lower_bound(
+    domain::Union{UniDistributionDomain,MultiDistributionDomain},
+    lower::Union{Real, Vector{<:Real}}
+    )
     error("Cannot set the lower bound of a distribution, try using " *
           "`Distributions.Truncated` instead.")
 end
 
 # CollectionDomain
-function JuMP.set_lower_bound(domain::CollectionDomain, lower::Vector{<:Real})::CollectionDomain
+function JuMP.set_lower_bound(domain::CollectionDomain, lower::Vector{<:Real})
     domains = collection_domains(domain)
     new_domains = [JuMP.set_lower_bound(domains[i], lower[i]) for i in eachindex(domains)]
     return CollectionDomain(new_domains)
@@ -218,18 +250,18 @@ julia> has_upper_bound(domain)
 true
 ```
 """
-function JuMP.has_upper_bound(domain::AbstractInfiniteDomain)::Bool # fallback
+function JuMP.has_upper_bound(domain::AbstractInfiniteDomain) # fallback
     return false
 end
 
 # IntervalDomain
-JuMP.has_upper_bound(domain::IntervalDomain)::Bool = true
+JuMP.has_upper_bound(domain::IntervalDomain) = true
 
 # DistributionDomain (Univariate)
-JuMP.has_upper_bound(domain::UniDistributionDomain)::Bool = true
+JuMP.has_upper_bound(domain::UniDistributionDomain) = true
 
 # CollectionDomain
-function JuMP.has_upper_bound(domain::CollectionDomain)::Bool
+function JuMP.has_upper_bound(domain::CollectionDomain)
     for i in collection_domains(domain)
         if !JuMP.has_upper_bound(i)
             return false
@@ -260,15 +292,15 @@ function JuMP.upper_bound(domain::AbstractInfiniteDomain) # fallback
 end
 
 # IntervalDomain
-JuMP.upper_bound(domain::IntervalDomain)::Float64 = domain.upper_bound
+JuMP.upper_bound(domain::IntervalDomain) = domain.upper_bound
 
 # DistributionDomain (Univariate)
-function JuMP.upper_bound(domain::UniDistributionDomain)::Real
+function JuMP.upper_bound(domain::UniDistributionDomain)
     return maximum(domain.distribution)
 end
 
 # CollectionDomain
-function JuMP.upper_bound(domain::CollectionDomain)::Vector{<:Real}
+function JuMP.upper_bound(domain::CollectionDomain)
     return [JuMP.upper_bound(i) for i in collection_domains(domain)]
 end
 
@@ -295,19 +327,21 @@ function JuMP.set_upper_bound(domain::AbstractInfiniteDomain, upper::Real) # fal
 end
 
 # IntervalDomain
-function JuMP.set_upper_bound(domain::IntervalDomain, upper::Real)::IntervalDomain
+function JuMP.set_upper_bound(domain::IntervalDomain, upper::Real)
     return IntervalDomain(domain.lower_bound, upper)
 end
 
 # DistributionDomain
-function JuMP.set_upper_bound(domain::Union{UniDistributionDomain,
-                                         MultiDistributionDomain}, lower::Real)
+function JuMP.set_upper_bound(
+    domain::Union{UniDistributionDomain,MultiDistributionDomain}, 
+    lower::Real
+    )
     error("Cannot set the upper bound of a distribution, try using " *
           "`Distributions.Truncated` instead.")
 end
 
 # CollectionDomain
-function JuMP.set_upper_bound(domain::CollectionDomain, lower::Vector{<:Real})::CollectionDomain
+function JuMP.set_upper_bound(domain::CollectionDomain, lower::Vector{<:Real})
     domains = collection_domains(domain)
     new_domains = [JuMP.set_upper_bound(domains[i], lower[i]) for i in eachindex(domains)]
     return CollectionDomain(new_domains)
@@ -451,20 +485,22 @@ should extend [`generate_support_values`](@ref) to enable this. Errors if the
 `domain` type and /or methods are unrecognized. This is intended as an internal
 method to be used by methods such as [`generate_and_add_supports!`](@ref).
 """
-function generate_supports(domain::AbstractInfiniteDomain;
-                           num_supports::Int = DefaultNumSupports,
-                           sig_digits::Int = DefaultSigDigits
-                           )::Tuple
+function generate_supports(
+    domain::AbstractInfiniteDomain;
+    num_supports::Int = DefaultNumSupports,
+    sig_digits::Int = DefaultSigDigits
+    )
     return generate_support_values(domain, num_supports = num_supports,
                                    sig_digits = sig_digits)
 end
 
 # 2 arguments
-function generate_supports(domain::AbstractInfiniteDomain,
-                           method::Type{<:AbstractSupportLabel};
-                           num_supports::Int = DefaultNumSupports,
-                           sig_digits::Int = DefaultSigDigits
-                           )::Tuple
+function generate_supports(
+    domain::AbstractInfiniteDomain,
+    method::Type{<:AbstractSupportLabel};
+    num_supports::Int = DefaultNumSupports,
+    sig_digits::Int = DefaultSigDigits
+    )
     return generate_support_values(domain, method,
                                    num_supports = num_supports,
                                    sig_digits = sig_digits)
@@ -486,8 +522,7 @@ method dispatches for a given domain must ensure that `method` is positional
 argument without a default value (contrary to the definition above). Note that the 
 `method` must be a subtype of either [`PublicLabel`](@ref) or [`InternalLabel`](@ref).
 """
-function generate_support_values(domain::AbstractInfiniteDomain,
-                                 args...; kwargs...)
+function generate_support_values(domain::AbstractInfiniteDomain, args...; kwargs...)
     if isempty(args)
         error("`generate_support_values` has not been extended for infinite domains " * 
               "of type `$(typeof(domain))`. This automatic support generation is not " * 
@@ -500,11 +535,12 @@ function generate_support_values(domain::AbstractInfiniteDomain,
 end
 
 # IntervalDomain and UniformGrid
-function generate_support_values(domain::IntervalDomain,
-                                 method::Type{UniformGrid} = UniformGrid;
-                                 num_supports::Int = DefaultNumSupports,
-                                 sig_digits::Int = DefaultSigDigits,
-                                 )::Tuple{Vector{<:Real}, DataType}
+function generate_support_values(
+    domain::IntervalDomain,
+    method::Type{UniformGrid} = UniformGrid;
+    num_supports::Int = DefaultNumSupports,
+    sig_digits::Int = DefaultSigDigits,
+    )
     lb = JuMP.lower_bound(domain)
     ub = JuMP.upper_bound(domain)
     new_supports = round.(range(lb, stop = ub, length = num_supports),
@@ -513,11 +549,12 @@ function generate_support_values(domain::IntervalDomain,
 end
 
 # IntervalDomain and MCSample
-function generate_support_values(domain::IntervalDomain,
-                                 method::Type{MCSample};
-                                 num_supports::Int = DefaultNumSupports,
-                                 sig_digits::Int = DefaultSigDigits,
-                                 )::Tuple{Vector{<:Real}, DataType}
+function generate_support_values(
+    domain::IntervalDomain,
+    method::Type{MCSample};
+    num_supports::Int = DefaultNumSupports,
+    sig_digits::Int = DefaultSigDigits,
+    )
     lb = JuMP.lower_bound(domain)
     ub = JuMP.upper_bound(domain)
     dist = Distributions.Uniform(lb, ub)
@@ -532,7 +569,7 @@ function generate_support_values(
     method::Type{WeightedSample} = WeightedSample;
     num_supports::Int = DefaultNumSupports,
     sig_digits::Int = DefaultSigDigits
-    )::Tuple{Array{<:Real}, DataType}
+    )
     dist = domain.distribution
     new_supports = round.(Distributions.rand(dist, num_supports),
                           sigdigits = sig_digits)
@@ -545,7 +582,7 @@ function generate_support_values(
     method::Type{MCSample};
     num_supports::Int = DefaultNumSupports,
     sig_digits::Int = DefaultSigDigits
-    )::Tuple{Vector{Float64}, DataType}
+    )
     return generate_support_values(domain, WeightedSample; num_supports = num_supports, 
                                    sig_digits = sig_digits)[1], method # TODO use an unwieghted sample...
 end
@@ -556,7 +593,7 @@ function generate_support_values(
     method::Type{WeightedSample} = WeightedSample;
     num_supports::Int = DefaultNumSupports,
     sig_digits::Int = DefaultSigDigits
-    )::Tuple{Array{Float64, 2}, DataType}
+    )
     dist = domain.distribution
     raw_supports = Distributions.rand(dist, num_supports)
     new_supports = Array{Float64}(undef, length(dist), num_supports)
@@ -568,8 +605,10 @@ function generate_support_values(
 end
 
 # Generate the supports for a collection domain
-function _generate_collection_supports(domain::CollectionDomain, num_supports::Int,
-                                       sig_digits::Int)::Array{Float64, 2}
+function _generate_collection_supports(
+    domain::CollectionDomain, num_supports::Int,
+    sig_digits::Int
+    )
     domains = collection_domains(domain)
     # build the support array transpose to fill in column order (leverage locality)
     trans_supports = Array{Float64, 2}(undef, num_supports, length(domains))
@@ -581,10 +620,12 @@ function _generate_collection_supports(domain::CollectionDomain, num_supports::I
     return permutedims(trans_supports)
 end
 
-function _generate_collection_supports(domain::CollectionDomain,
-                                       method::Type{<:AbstractSupportLabel},
-                                       num_supports::Int,
-                                       sig_digits::Int)::Array{Float64, 2}
+function _generate_collection_supports(
+    domain::CollectionDomain,
+    method::Type{<:AbstractSupportLabel},
+    num_supports::Int,
+    sig_digits::Int
+    )
     domains = collection_domains(domain)
     # build the support array transpose to fill in column order (leverage locality)
     trans_supports = Array{Float64, 2}(undef, num_supports, length(domains))
@@ -598,59 +639,66 @@ function _generate_collection_supports(domain::CollectionDomain,
 end
 
 # CollectionDomain (IntervalDomains)
-function generate_support_values(domain::CollectionDomain{IntervalDomain},
-                                 method::Type{UniformGrid} = UniformGrid;
-                                 num_supports::Int = DefaultNumSupports,
-                                 sig_digits::Int = DefaultSigDigits
-                                 )::Tuple{Array{<:Real}, DataType}
+function generate_support_values(
+    domain::CollectionDomain{IntervalDomain},
+    method::Type{UniformGrid} = UniformGrid;
+    num_supports::Int = DefaultNumSupports,
+    sig_digits::Int = DefaultSigDigits
+    )
     new_supports = _generate_collection_supports(domain, num_supports, sig_digits)
     return new_supports, method
 end
 
-function generate_support_values(domain::CollectionDomain{IntervalDomain},
-                                 method::Type{MCSample};
-                                 num_supports::Int = DefaultNumSupports,
-                                 sig_digits::Int = DefaultSigDigits
-                                 )::Tuple{Array{<:Real}, DataType}
+function generate_support_values(
+    domain::CollectionDomain{IntervalDomain},
+    method::Type{MCSample};
+    num_supports::Int = DefaultNumSupports,
+    sig_digits::Int = DefaultSigDigits
+    )
     new_supports = _generate_collection_supports(domain, method, num_supports, sig_digits)
     return new_supports, method
 end
 
 # CollectionDomain (UniDistributionDomains)
-function generate_support_values(domain::CollectionDomain{<:UniDistributionDomain},
-                                 method::Type{WeightedSample} = WeightedSample;
-                                 num_supports::Int = DefaultNumSupports,
-                                 sig_digits::Int = DefaultSigDigits
-                                 )::Tuple{Array{<:Real}, DataType}
+function generate_support_values(
+    domain::CollectionDomain{<:UniDistributionDomain},
+    method::Type{WeightedSample} = WeightedSample;
+    num_supports::Int = DefaultNumSupports,
+    sig_digits::Int = DefaultSigDigits
+    )
     new_supports = _generate_collection_supports(domain, num_supports, sig_digits)
     return new_supports, method
 end
 
 # CollectionDomain (InfiniteScalarDomains)
-function generate_support_values(domain::CollectionDomain,
-                                 method::Type{Mixture} = Mixture;
-                                 num_supports::Int = DefaultNumSupports,
-                                 sig_digits::Int = DefaultSigDigits
-                                 )::Tuple{Array{<:Real}, DataType}
+function generate_support_values(
+    domain::CollectionDomain,
+    method::Type{Mixture} = Mixture;
+    num_supports::Int = DefaultNumSupports,
+    sig_digits::Int = DefaultSigDigits
+    )
     new_supports = _generate_collection_supports(domain, num_supports, sig_digits)
     return new_supports, method
 end
 
 # CollectionDomain (InfiniteScalarDomains) using purely MC sampling
 # this is useful for measure support generation
-function generate_support_values(domain::CollectionDomain,
-                                 method::Type{MCSample};
-                                 num_supports::Int = DefaultNumSupports,
-                                 sig_digits::Int = DefaultSigDigits
-                                 )::Tuple{Array{<:Real}, DataType}
+function generate_support_values(
+    domain::CollectionDomain,
+    method::Type{MCSample};
+    num_supports::Int = DefaultNumSupports,
+    sig_digits::Int = DefaultSigDigits
+    )
     new_supports = _generate_collection_supports(domain, method, num_supports, sig_digits)
     return new_supports, method
 end
 
 # For label All: dispatch to default methods
-function generate_support_values(domain::AbstractInfiniteDomain, ::Type{All};
-                                 num_supports::Int = DefaultNumSupports,
-                                 sig_digits::Int = DefaultSigDigits)
+function generate_support_values(
+    domain::AbstractInfiniteDomain, ::Type{All};
+    num_supports::Int = DefaultNumSupports,
+    sig_digits::Int = DefaultSigDigits
+    )
     return generate_support_values(domain, num_supports = num_supports,
                                    sig_digits = sig_digits)
 end

--- a/src/scalar_parameters.jl
+++ b/src/scalar_parameters.jl
@@ -185,7 +185,7 @@ function build_parameter(
     for (kwarg, _) in extra_kwargs
         _error("Unrecognized keyword argument $kwarg")
     end
-    domain = _round_domain(domain, sig_digits)
+    domain = round_domain(domain, sig_digits)
     label = UserDefined
     length_supports = length(supports)
     if !isempty(supports)

--- a/test/array_parameters.jl
+++ b/test/array_parameters.jl
@@ -118,7 +118,7 @@ end
         @test_throws ErrorException InfiniteOpt._build_parameters(error, [domain1, domain1], inds1, supports = [[0, 0], [2]])
         @test_throws ErrorException InfiniteOpt._build_parameters(error, [domain1, domain1], inds1, derivative_method = [2, 2])
         # test vector 
-        @test InfiniteOpt._build_parameters(error, [domain1, domain1], inds1).domain == domain1 
+        @test InfiniteOpt._build_parameters(error, [domain1, domain1], inds1).domain isa CollectionDomain
         @test InfiniteOpt._build_parameters(error, [domain1, domain1], inds1).supports == Dict{Vector{Float64}, Set{DataType}}()
         @test InfiniteOpt._build_parameters(error, [domain1, domain1],  inds1, supports = [0, 0]).supports == Dict([0., 0.] => Set([UserDefined]))
         @test InfiniteOpt._build_parameters(error, [domain1, domain1], inds1).sig_digits isa Int 

--- a/test/extensions/infinite_domain.jl
+++ b/test/extensions/infinite_domain.jl
@@ -10,11 +10,22 @@ struct MyNewDomain <: InfiniteOpt.InfiniteScalarDomain
     end
 end
 
+# Extend round_domain (only needed if rounding is appropriate for MyNewDomain)
+function InfiniteOpt.round_domain(
+    domain::MyNewDomain,
+    sig_digits::Int
+    )
+    # Recreate the domain with proper significant digits
+    attr1 = round(domain.attr1, sigdigits = sig_digits) # REPLACE WITH ROUNDING FOR YOUR DOMAIN
+    attr2 = round(domain.attr2, sigdigits = sig_digits) # REPLACE WITH ROUNDING FOR YOUR DOMAIN
+    return MyNewDomain(attr1, attr2)
+end
+
 # Extend supports_in_domain
 function InfiniteOpt.supports_in_domain(
     supports::Union{Real, Vector{<:Real}},
     domain::MyNewDomain
-    )::Bool
+    )
     # DETERMINE IF SUPPORTS ARE IN THE DOMAIN OF `domain`
     in_domain = all(domain.attr1 .<= supports .<= domain.attr2) # REPLACE WITH ACTUAL CHECK
     return in_domain
@@ -25,14 +36,14 @@ function InfiniteOpt.generate_support_values(
     domain::MyNewDomain;
     num_supports::Int = 10,
     sig_digits::Int = 5
-    )::Tuple{Vector{Float64}, DataType}
+    )
     # REPLACE BELOW WITH METHODS TO GENERATE `num_samples` with `sig_fig` 
     supports = collect(range(domain.attr1, stop = domain.attr2, length = num_supports))
     return round.(supports, sigdigits = sig_digits), UniformGrid
 end
 
 # Extend JuMP.has_lower_bound (optional if the answer is always false)
-function JuMP.has_lower_bound(domain::MyNewDomain)::Bool
+function JuMP.has_lower_bound(domain::MyNewDomain)
     # INSERT NECESSARY CHECKS IF NEEDED
     has_bound = true # REPLACE WITH ACTUAL RESULT
     return has_bound
@@ -44,12 +55,12 @@ function JuMP.lower_bound(domain::MyNewDomain)
 end
 
 # Extend JuMP.set_lower_bound if appropriate
-function JuMP.set_lower_bound(domain::MyNewDomain, lower::Real)::MyNewDomain
+function JuMP.set_lower_bound(domain::MyNewDomain, lower::Real)
     return MyNewDomain(lower, domain.attr2) # REPLACE WITH ACTUAL CONSTRUCTOR
 end
 
 # Extend JuMP.has_upper_bound (optional if the answer is always false)
-function JuMP.has_upper_bound(domain::MyNewDomain)::Bool
+function JuMP.has_upper_bound(domain::MyNewDomain)
     # INSERT NECESSARY CHECKS IF NEEDED
     has_bound = true # REPLACE WITH ACTUAL RESULT
     return has_bound
@@ -61,7 +72,7 @@ function JuMP.upper_bound(domain::MyNewDomain)
 end
 
 # Extend JuMP.set_upper_bound if appropriate
-function JuMP.set_upper_bound(domain::MyNewDomain, upper::Real)::MyNewDomain
+function JuMP.set_upper_bound(domain::MyNewDomain, upper::Real)
     return MyNewDomain(domain.attr1, upper) # REPLACE WITH ACTUAL CONSTRUCTOR
 end
 

--- a/test/scalar_parameters.jl
+++ b/test/scalar_parameters.jl
@@ -1093,4 +1093,12 @@ end
         @test fill_in_supports!(pref1, num_supports = 20) isa Nothing
         @test length(supports(pref1)) == 20
     end
+    # test sigfig changes on infinite domain
+    @testset "Sigfig support addition test" begin
+        m = InfiniteModel()
+        supps = [0.8236475079774124, 0.9103565379264364]
+        @infinite_parameter(m, p in [supps[1], supps[2]])
+        @test fill_in_supports!(p, num_supports = 8) isa Nothing
+        @test length(supports(p)) == 8
+    end
 end


### PR DESCRIPTION
If domains are specified with more sigfigs than are used for the supports, then an out of bounds error will likely result. To fix this, domains are now rounded to the same amount of sigfigs as well. See https://discourse.julialang.org/t/infiniteopt-supports-violate-the-domain-bounds/115751. 
