### PR TITLE
Use `OrderedDict` for Array Parameter Supports

### DIFF
--- a/docs/src/guide/parameter.md
+++ b/docs/src/guide/parameter.md
@@ -271,8 +271,8 @@ the distribution.
 ```jldoctest macro_define
 julia> supports(θ)
 2×3 Matrix{Float64}:
- -0.353007  0.679107  0.586617
- -0.190712  1.17155   0.420496
+ 0.679107  -0.353007  0.586617
+ 1.17155   -0.190712  0.420496
 ```
 We refer to groups of parameters defined this way as dependent infinite 
 parameters. In principle, nonrandom infinite parameter types can be made 
@@ -518,8 +518,8 @@ julia> fill_in_supports!(ξ, num_supports = 3)
 
 julia> supports(ξ)
 2×3 Matrix{Float64}:
- -0.353007  0.679107  0.586617
- -0.190712  1.17155   0.420496
+ 0.679107  -0.353007  0.586617
+ 1.17155   -0.190712  0.420496
 ```
 Note that [`fill_in_supports!`](@ref) only fill in supports for parameters with no 
 associated supports. To modify the supports of parameters already associated 

--- a/src/array_parameters.jl
+++ b/src/array_parameters.jl
@@ -166,7 +166,9 @@ function _process_supports(
         _error("Support violates the infinite domain.")
     end
     supps = round.(supps, sigdigits = sig_digits)
-    return Dict{Vector{Float64}, Set{DataType}}(supps => Set([UserDefined]))
+    return DataStructures.OrderedDict{Vector{Float64}, Set{DataType}}(
+        supps => Set([UserDefined])
+        )
 end
 
 # Vector{Vector{<:Real}}
@@ -185,8 +187,9 @@ function _process_supports(
         _error("Supports violate the infinite domain.")
     end
     supps = round.(supps, sigdigits = sig_digits)
-    return Dict{Vector{Float64}, Set{DataType}}(s => Set([UserDefined]) 
-                                                for s in eachcol(supps))
+    return DataStructures.OrderedDict{Vector{Float64}, Set{DataType}}(
+        s => Set([UserDefined]) for s in eachcol(supps)
+        )
 end
 
 ## Use dispatch to make the formatting of the derivative method vector 
@@ -235,14 +238,17 @@ function _build_parameters(
         supp_dict = _process_supports(_error, supports, domain, sig_digits)
     # we want to generate supports
     elseif !iszero(num_supports)
-        supps, label = generate_support_values(domain, 
-                                               num_supports = num_supports,
-                                               sig_digits = sig_digits)
-        supp_dict = Dict{Vector{Float64}, Set{DataType}}(s => Set([label]) 
-                                                         for s in eachcol(supps))
+        supps, label = generate_support_values(
+            domain, 
+            num_supports = num_supports,
+            sig_digits = sig_digits
+            )
+        supp_dict = DataStructures.OrderedDict{Vector{Float64}, Set{DataType}}(
+            s => Set([label]) for s in eachcol(supps)
+            )
     # no supports are specified
     else
-        supp_dict = Dict{Vector{Float64}, Set{DataType}}()
+        supp_dict = DataStructures.OrderedDict{Vector{Float64}, Set{DataType}}()
     end
     # check the derivative methods
     methods = _process_derivative_methods(_error, derivative_method, domains)
@@ -351,32 +357,27 @@ end
 #                           PARAMETER DEPENDENCIES
 ################################################################################
 # Extend _infinite_variable_dependencies
-function _infinite_variable_dependencies(pref::DependentParameterRef
-    )::Vector{InfiniteVariableIndex}
+function _infinite_variable_dependencies(pref::DependentParameterRef)
     return _data_object(pref).infinite_var_indices
 end
 
 # Extend _parameter_function_dependencies
-function _parameter_function_dependencies(pref::DependentParameterRef
-    )::Vector{ParameterFunctionIndex}
+function _parameter_function_dependencies(pref::DependentParameterRef)
     return _data_object(pref).parameter_func_indices
 end
 
 # Extend _measure_dependencies
-function _measure_dependencies(pref::DependentParameterRef
-    )::Vector{MeasureIndex}
+function _measure_dependencies(pref::DependentParameterRef)
     return _data_object(pref).measure_indices[_param_index(pref)]
 end
 
 # Extend _constraint_dependencies
-function _constraint_dependencies(pref::DependentParameterRef
-    )::Vector{InfOptConstraintIndex}
+function _constraint_dependencies(pref::DependentParameterRef)
     return _data_object(pref).constraint_indices[_param_index(pref)]
 end
 
 # Extend _derivative_dependencies
-function _derivative_dependencies(pref::DependentParameterRef
-    )::Vector{DerivativeIndex}
+function _derivative_dependencies(pref::DependentParameterRef)
     return _data_object(pref).derivative_indices[_param_index(pref)]
 end
 
@@ -741,8 +742,7 @@ function _update_parameter_domain(
     pref::DependentParameterRef,
     new_domain::InfiniteArrayDomain
     )
-    old_params = core_object(pref)
-    new_supports = Dict{Vector{Float64}, Set{DataType}}()
+    new_supports = DataStructures.OrderedDict{Vector{Float64}, Set{DataType}}()
     sig_figs = significant_digits(pref)
     methods = _derivative_methods(pref)
     new_params = DependentParameters(new_domain, new_supports, sig_figs, methods)
@@ -790,8 +790,10 @@ function set_infinite_domain(
               "a measure.")
     end
     param_idx = _param_index(pref)
-    new_domain = CollectionDomain([i != param_idx ? collection_domains(old_domain)[i] : domain
-                             for i in eachindex(collection_domains(old_domain))])
+    new_domain = CollectionDomain(
+        [i != param_idx ? collection_domains(old_domain)[i] : domain
+        for i in eachindex(collection_domains(old_domain))]
+        )
     _update_parameter_domain(pref, new_domain)
     return
 end
@@ -1168,8 +1170,9 @@ function _update_parameter_supports(
     label::Type{<:AbstractSupportLabel}
     )
     domain = _parameter_domain(first(prefs))
-    new_supps = Dict{Vector{Float64}, Set{DataType}}(s => Set([label]) 
-                                                     for s in eachcol(supports))
+    new_supps = DataStructures.OrderedDict{Vector{Float64}, Set{DataType}}(
+        s => Set([label]) for s in eachcol(supports)
+        )
     sig_figs = significant_digits(first(prefs))
     methods = _derivative_methods(first(prefs))
     new_params = DependentParameters(domain, new_supps, sig_figs, methods)
@@ -1438,9 +1441,11 @@ function generate_and_add_supports!(
     domain::InfiniteArrayDomain;
     num_supports::Int = DefaultNumSupports
     )
-    new_supps, label = generate_supports(domain,
-                                         num_supports = num_supports,
-                                    sig_digits = significant_digits(first(prefs)))
+    new_supps, label = generate_supports(
+        domain,
+        num_supports = num_supports,
+        sig_digits = significant_digits(first(prefs))
+        )
     add_supports(Collections.vectorize(prefs), new_supps, check = false, 
                  label = label)
     return
@@ -1453,9 +1458,11 @@ function generate_and_add_supports!(
     method::Type{<:AbstractSupportLabel};
     num_supports::Int = DefaultNumSupports
     )
-    new_supps, label = generate_supports(domain, method,
-                                         num_supports = num_supports,
-                                    sig_digits = significant_digits(first(prefs)))
+    new_supps, label = generate_supports(
+        domain, method,
+        num_supports = num_supports,
+        sig_digits = significant_digits(first(prefs))
+        )
     add_supports(Collections.vectorize(prefs), new_supps, check = false, 
                  label = label)
     return

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -523,7 +523,7 @@ A `DataType` for storing a collection of dependent infinite parameters.
 
 **Fields**
 - `domain::T`: The infinite domain that characterizes the parameters.
-- `supports::Dict{Vector{Float64}, Set{DataType}}`: Support dictionary where keys
+- `supports::DataStructures.OrderedDict{Vector{Float64}, Set{DataType}}`: Support dictionary where keys
               are supports and the values are the set of labels for each support.
 - `sig_digits::Int`: The number of significant digits used to round the support values.
 - `derivative_methods::Vector{M}`: The derivative evaluation methods associated with 
@@ -532,7 +532,7 @@ A `DataType` for storing a collection of dependent infinite parameters.
 struct DependentParameters{T <: InfiniteArrayDomain, 
                            M <: NonGenerativeDerivativeMethod} <: InfOptParameter
     domain::T
-    supports::Dict{Vector{Float64}, Set{DataType}} # Support to label set
+    supports::DataStructures.OrderedDict{Vector{Float64}, Set{DataType}} # Support to label set
     sig_digits::Int
     derivative_methods::Vector{M}
 end

--- a/test/TranscriptionOpt/model.jl
+++ b/test/TranscriptionOpt/model.jl
@@ -348,7 +348,7 @@ end
         add_supports(par, 0.6, label = InternalLabel)
         @test IOTO.set_parameter_supports(tb, m) isa Nothing 
         expected = ([[0., 0.], [1., 1.], [NaN, NaN]], [0., 0.3, 0.6, 0.8, 1., NaN])
-        @test isequal(sort.(IOTO.transcription_data(tb).supports), expected)
+        @test isequal(IOTO.transcription_data(tb).supports, expected)
         @test IOTO.has_internal_supports(tb)
         expected = ([Set([UniformGrid]), Set([UniformGrid]), Set{DataType}()], 
                     [Set([UserDefined]), Set([InternalGaussLobatto]), 
@@ -361,7 +361,7 @@ end
     # test parameter_supports
     @testset "parameter_supports" begin 
     expected = ([[0., 0.], [1., 1.], [NaN, NaN]], [0., 0.3, 0.6, 0.8, 1., NaN])
-        @test isequal(sort.(IOTO.parameter_supports(tb)), expected)
+        @test isequal(IOTO.parameter_supports(tb), expected)
     end
     # test support_index_iterator with 1 argument
     @testset "support_index_iterator (1 Arg)" begin 

--- a/test/array_parameters.jl
+++ b/test/array_parameters.jl
@@ -6,7 +6,7 @@
     idx = DependentParameterIndex(obj_idx, 1)
     domain = CollectionDomain([IntervalDomain(0, 1), IntervalDomain(0, 1)])
     methods = [InfiniteOpt.DefaultDerivativeMethod for i = 1:2]
-    params = DependentParameters(domain, Dict{Vector{Float64}, Set{DataType}}(), 5, methods)
+    params = DependentParameters(domain, OrderedDict{Vector{Float64}, Set{DataType}}(), 5, methods)
     object = MultiParameterData(params, 1, 1:2, ["p1", "p2"])
     pref = DependentParameterRef(m, idx)
     gvref = GeneralVariableRef(m, 1, DependentParameterIndex, 1)
@@ -90,11 +90,11 @@ end
     # test _process_supports
     @testset "_process_supports" begin
         # single support
-        supps = Dict([0., 0.] => Set([UserDefined]))
+        supps = OrderedDict([0., 0.] => Set([UserDefined]))
         @test InfiniteOpt._process_supports(error, [0, 0], domain1, 2) == supps
         @test_throws ErrorException InfiniteOpt._process_supports(error, [2, 2], domain1, 2)
         # multiple supports 
-        supps = Dict([0., 0.] => Set([UserDefined]), [1., 1.] => Set([UserDefined]))
+        supps = OrderedDict([0., 0.] => Set([UserDefined]), [1., 1.] => Set([UserDefined]))
         @test InfiniteOpt._process_supports(error, [[0, 1], [0, 1]], domain1, 2) == supps
         @test_throws ErrorException InfiniteOpt._process_supports(error, [[0, 0], [1]], domain1, 2)
         @test_throws ErrorException InfiniteOpt._process_supports(error, [[0, 2], [0, 2]], domain1, 2)
@@ -119,13 +119,13 @@ end
         @test_throws ErrorException InfiniteOpt._build_parameters(error, [domain1, domain1], inds1, derivative_method = [2, 2])
         # test vector 
         @test InfiniteOpt._build_parameters(error, [domain1, domain1], inds1).domain isa CollectionDomain
-        @test InfiniteOpt._build_parameters(error, [domain1, domain1], inds1).supports == Dict{Vector{Float64}, Set{DataType}}()
-        @test InfiniteOpt._build_parameters(error, [domain1, domain1],  inds1, supports = [0, 0]).supports == Dict([0., 0.] => Set([UserDefined]))
+        @test InfiniteOpt._build_parameters(error, [domain1, domain1], inds1).supports == OrderedDict{Vector{Float64}, Set{DataType}}()
+        @test InfiniteOpt._build_parameters(error, [domain1, domain1],  inds1, supports = [0, 0]).supports == OrderedDict([0., 0.] => Set([UserDefined]))
         @test InfiniteOpt._build_parameters(error, [domain1, domain1], inds1).sig_digits isa Int 
         @test InfiniteOpt._build_parameters(error, [domain1, domain1], inds1).derivative_methods == [method, method]
         # test array 
         @test InfiniteOpt._build_parameters(error, [domain3 for i in 1:4], inds2).domain == domain3 
-        @test InfiniteOpt._build_parameters(error, [domain3 for i in 1:4], inds2, supports = [[0, 1] for i in 1:4]).supports == Dict(zeros(4) => Set([UserDefined]), ones(4) => Set([UserDefined]))
+        @test InfiniteOpt._build_parameters(error, [domain3 for i in 1:4], inds2, supports = [[0, 1] for i in 1:4]).supports == OrderedDict(zeros(4) => Set([UserDefined]), ones(4) => Set([UserDefined]))
         @test length(InfiniteOpt._build_parameters(error, [domain3 for i in 1:4], inds2, num_supports = 2).supports) == 2
         @test InfiniteOpt._build_parameters(error, [domain3 for i in 1:4], inds2, sig_digits = 3).sig_digits == 3
         @test InfiniteOpt._build_parameters(error, [domain3 for i in 1:4], inds2, derivative_method = [TestMethod() for i in 1:4]).derivative_methods isa Vector{TestMethod} 
@@ -208,7 +208,7 @@ end
         expected = JuMPC.DenseAxisArray(prefs, 3:4)
         @test isequal(@infinite_parameter(m, b[3:4] in domain2, supports = 0), expected)
         @test name.(prefs) == ["b[3]", "b[4]"]
-        @test core_object(prefs[1]).supports == Dict{Vector{Float64}, Set{DataType}}(zeros(2) => Set([UserDefined]))
+        @test core_object(prefs[1]).supports == OrderedDict{Vector{Float64}, Set{DataType}}(zeros(2) => Set([UserDefined]))
         # test explicit build with some args
         prefs = [GeneralVariableRef(m, 3, DependentParameterIndex, i) for i in 1:2]
         expected = convert(JuMPC.SparseAxisArray, prefs)
@@ -426,7 +426,7 @@ end
     data = InfiniteOpt._data_object(first(prefs))
     domain = CollectionDomain([IntervalDomain(0, 2), IntervalDomain(0, 2)])
     methods = [InfiniteOpt.DefaultDerivativeMethod for i = 1:2]
-    params = DependentParameters(domain, Dict{Vector{Float64}, Set{DataType}}(), 10, methods)
+    params = DependentParameters(domain, OrderedDict{Vector{Float64}, Set{DataType}}(), 10, methods)
     bad_idx = DependentParameterIndex(DependentParametersIndex(-1), 2)
     bad_pref = DependentParameterRef(m, bad_idx)
     # test _parameter_number
@@ -460,7 +460,7 @@ end
         @test InfiniteOpt._adaptive_data_update(prefs[1], params, data) isa Nothing
         # test with different data 
         domain = MultiDistributionDomain(MvNormal([0, 0], LinearAlgebra.Diagonal(map(abs2, [1, 1]))))
-        ps = DependentParameters(domain, Dict{Vector{Float64}, Set{DataType}}(), 10, methods)
+        ps = DependentParameters(domain, OrderedDict{Vector{Float64}, Set{DataType}}(), 10, methods)
         @test InfiniteOpt._adaptive_data_update(prefs[2], ps, data) isa Nothing
         @test core_object(prefs[2]) == ps
     end

--- a/test/datatypes.jl
+++ b/test/datatypes.jl
@@ -165,14 +165,14 @@ end
     # test DependentParameters
     @test DependentParameters <: InfOptParameter
     @test DependentParameters(CollectionDomain([IntervalDomain(0, 1)]),
-                              Dict(zeros(1) => Set([All])), 6, [method]).domain isa CollectionDomain
+                              OrderedDict(zeros(1) => Set([All])), 6, [method]).domain isa CollectionDomain
     # test ScalarParameterData
     @test ScalarParameterData <: AbstractDataObject
     @test ScalarParameterData(FiniteParameter(42), 1, 1, "bob").name == "bob"
     # test MultiParameterData
     @test MultiParameterData <: AbstractDataObject
     params = DependentParameters(CollectionDomain([IntervalDomain(0, 1)]),
-                                 Dict(zeros(1) => Set([All])), 6, [method])
+                                 OrderedDict(zeros(1) => Set([All])), 6, [method])
     @test MultiParameterData(params, 1, 1:1, ["par[1]"]) isa MultiParameterData
 end
 


### PR DESCRIPTION
The use of `Dict` for multi-dimensional dependent infinite parameter supports leads to stochastic ordering of supports. This is problematic when the user queries the results, since the ordering cannot be known a priori. Hence, this PR simply replaces `Dict` with `DataStructures.OrderedDict`.