### PR TITLE
Improve Performance of Internal Semi-Infinite Variables

### DIFF
--- a/src/TranscriptionOpt/measures.jl
+++ b/src/TranscriptionOpt/measures.jl
@@ -74,7 +74,24 @@ function InfiniteOpt.add_semi_infinite_variable(
         # make the reference and map it to a transcription variable
         rvref = InfiniteOpt.GeneralVariableRef(inf_model, raw_index, InfiniteOpt.SemiInfiniteVariableIndex)
         push!(semi_infinite_vars, var)
-        _set_semi_infinite_variable_mapping(backend, var, rvref, InfiniteOpt._index_type(ivref))
+        if ivref.index_type != InfiniteOpt.ParameterFunctionIndex
+            ivref_param_nums = InfiniteOpt._parameter_numbers(ivref)
+            param_nums = var.parameter_nums
+            supp_indices = support_index_iterator(backend, var.group_int_idxs)
+            lookup_dict = Dict{Vector{Float64}, JuMP.VariableRef}()
+            sizehint!(lookup_dict, length(supp_indices))
+            for i in supp_indices
+                raw_supp = index_to_support(backend, i)
+                if any(!isnan(raw_supp[ivref_param_nums[k]]) && raw_supp[ivref_param_nums[k]] != v for (k, v) in eval_supps)
+                    continue
+                end
+                ivref_supp = [haskey(eval_supps, j) ? eval_supps[j] : raw_supp[k] 
+                            for (j, k) in enumerate(ivref_param_nums)]
+                supp = raw_supp[param_nums]
+                lookup_dict[supp] = lookup_by_support(ivref, backend, ivref_supp)
+            end
+            data.infvar_lookup[rvref] = lookup_dict
+        end
         data.semi_lookup[(ivref, eval_supps)] = rvref
         return rvref
     end

--- a/test/TranscriptionOpt/measure.jl
+++ b/test/TranscriptionOpt/measure.jl
@@ -49,14 +49,18 @@
         vref = GeneralVariableRef(m, -1, SemiInfiniteVariableIndex)
         @test isequal(InfiniteOpt.add_semi_infinite_variable(tb, var), vref)
         @test isequal(data.semi_infinite_vars, [var])
-        @test c in IOTO.transcription_variable(vref)
-        @test d in IOTO.transcription_variable(vref)
-        @test sort!(supports(vref)) == [([0., 0.], ), ([1., 1.], )]
+        @test IOTO.transcription_expression(vref, tb, [1., 0., 0.]) == c
+        @test IOTO.transcription_expression(vref, tb, [1., 1., 1.]) == d
         # add one that has already been added internally
         @test isequal(InfiniteOpt.add_semi_infinite_variable(tb, var), vref)
         @test isequal(data.semi_infinite_vars, [var])
-        @test c in IOTO.transcription_variable(vref)
-        @test d in IOTO.transcription_variable(vref)
-        @test sort!(supports(vref)) == [([0., 0.], ), ([1., 1.], )]
+        @test IOTO.transcription_expression(vref, tb, [1., 0., 0.]) == c
+        @test IOTO.transcription_expression(vref, tb, [1., 1., 1.]) == d
+        # test with partially evaluated dependent parameter group
+        var2 = SemiInfiniteVariable(y, Dict(1 => 1., 2 => 1.0), [3], [2])
+        vref = GeneralVariableRef(m, -2, SemiInfiniteVariableIndex)
+        @test isequal(InfiniteOpt.add_semi_infinite_variable(tb, var2), vref)
+        @test isequal(data.semi_infinite_vars, [var, var2])
+        @test IOTO.transcription_expression(vref, tb, [1., 1., 1.]) == d
     end
 end

--- a/test/TranscriptionOpt/transcribe.jl
+++ b/test/TranscriptionOpt/transcribe.jl
@@ -116,21 +116,11 @@
         @test supports(dx) == [(0,), (1,)]
         @test supports(dy) == [(0, [0, 0]) (0, [1, 1]); (1, [0, 0]) (1, [1, 1])]
     end
-    # test _set_semi_infinite_variable_mapping
-    @testset "_set_semi_infinite_variable_mapping" begin 
-        var = SemiInfiniteVariable(y, Dict{Int, Float64}(1 => 0), [1, 2], [1])
-        vref = GeneralVariableRef(m, -1, SemiInfiniteVariableIndex)
-        @test IOTO._set_semi_infinite_variable_mapping(tb, var, vref, SemiInfiniteVariableIndex) isa Nothing 
-        @test IOTO.transcription_variable(vref) isa Vector{VariableRef}
-        @test length(IOTO.transcription_data(tb).infvar_mappings) == 7
-        @test IOTO.lookup_by_support(y, tb, [0., 0, 0]) == IOTO.lookup_by_support(vref, tb, [0., 0])
-        @test IOTO._set_semi_infinite_variable_mapping(tb, var, vref, ParameterFunctionIndex) isa Nothing 
-    end
     # test transcribe_semi_infinite_variables!
     @testset "transcribe_semi_infinite_variables!" begin 
         @test IOTO.transcribe_semi_infinite_variables!(tb, m) isa Nothing
         @test IOTO.transcription_variable(yrv) isa Vector{VariableRef}
-        @test length(IOTO.transcription_data(tb).infvar_mappings) == 8
+        @test length(IOTO.transcription_data(tb).infvar_mappings) == 7
         @test IOTO.lookup_by_support(y, tb, [1., 0., 0.]) == IOTO.lookup_by_support(yrv, tb, [1., 0])
     end
     # test _update_point_info


### PR DESCRIPTION
#356 added a lot of unneeded operations for semi-infinite variables that are generated internally during transcription. This removes the unnecessary operations and allocations.