### PR TITLE
Fix bug in `restricted_copy`

### DIFF
--- a/src/Collections/VectorTuple.jl
+++ b/src/Collections/VectorTuple.jl
@@ -218,6 +218,7 @@ function _update_indices(inds::ContainerIndices{1, <:Vector}, i)
     new_axes = deleteat!(copy(inds.axes), i)
     cart_inds = CartesianIndices(new_axes)
     return length(new_axes) >= 2 ? ContainerIndices(cart_inds, new_axes) : nothing
+    # return ContainerIndices(cart_inds, new_axes)
 end
 
 # DenseAxisArray
@@ -243,7 +244,7 @@ function restricted_copy(vt::VectorTuple, inds::AbstractVector{<:Bool})
     prev_sum = 0
     delete_inds = Int[]
     new_ranges = copy(vt.ranges)
-    new_indices = collect(vt.indices)
+    new_indices = collect(Any, vt.indices)
     for i in eachindex(new_ranges)
         delete_sum = sum(inv_inds[new_ranges[i]])
         if length(new_ranges[i]) == delete_sum

--- a/test/Collections/VectorTuple.jl
+++ b/test/Collections/VectorTuple.jl
@@ -276,6 +276,9 @@
             copy_inds = [false, false, true, false, true, true, false, true]
             @test IC.restricted_copy(vt, copy_inds) == IC.VectorTuple(cs, new_d)
             @test vt == IC.VectorTuple(a, c, d)
+            # test with partial reduction of an vector
+            vt = IC.VectorTuple([1, 2])
+            @test IC.restricted_copy(vt, [true, false]) == IC.VectorTuple(1)
         end
     end
 


### PR DESCRIPTION
A previously unnoticed is bug occurred with the following:
```julia
julia> vt = VectorTuple([1, 2])
([1, 2],)

julia> InfiniteOpt.Collections.restricted_copy(vt, [true, false])
ERROR: MethodError: Cannot `convert` an object of type Nothing to an object of type InfiniteOpt.Collections.ContainerIndices{1, Nothing}

Closest candidates are:
  convert(::Type{T}, ::T) where T
   @ Base Base.jl:64
  (::Type{InfiniteOpt.Collections.ContainerIndices{N, Ax}} where {N, Ax})(::Any, ::Any)
   @ InfiniteOpt C~\InfiniteOpt.jl\src\Collections\vectorize.jl:11

Stacktrace:
 [1] setindex!(A::Vector{InfiniteOpt.Collections.ContainerIndices{1, Nothing}}, x::Nothing, i1::Int64)
   @ Base .\array.jl:969
 [2] restricted_copy(vt::VectorTuple{Int64, Tuple{InfiniteOpt.Collections.ContainerIndices{1, Nothing}}}, inds::Vector{Bool})
   @ InfiniteOpt.Collections ~\InfiniteOpt.jl\src\Collections\VectorTuple.jl:254
 [3] top-level scope
   @ REPL[25]:1
```
This is due to incorrect typing on a Vector. This PR fixes this bug.
