### PR TITLE
Improve Defaults of `JuMP.is_binary`, `JuMP.is_integer`, and `JuMP.is_fixed`

### DIFF
--- a/src/general_variables.jl
+++ b/src/general_variables.jl
@@ -820,10 +820,14 @@ for op = (:has_lower_bound, :has_upper_bound, :is_fixed, :is_binary, :is_integer
           :unset_integer)
     @eval begin
         # define the fallback method
-        function JuMP.$op(vref::DispatchVariableRef)
-            str = string("`JuMP.$($op)` not defined for variable reference type ",
-                         "`$(typeof(vref))`.")
-            throw(ArgumentError(str))
+        if JuMP.$op in (JuMP.is_binary, JuMP.is_fixed, JuMP.is_integer)
+            JuMP.$op(vref::DispatchVariableRef) = false
+        else
+            function JuMP.$op(vref::DispatchVariableRef)
+                str = string("`JuMP.$($op)` not defined for variable reference type ",
+                            "`$(typeof(vref))`.")
+                throw(ArgumentError(str))
+            end
         end
 
         # define the dispatch version

--- a/test/general_variables.jl
+++ b/test/general_variables.jl
@@ -484,13 +484,17 @@ end
     gvref = GeneralVariableRef(m, 1, TestIndex)
     pref = GeneralVariableRef(m, -1, IndependentParameterIndex)
     # test 1 argument methods 
-    for f in (:has_lower_bound, :has_upper_bound, :is_fixed, :is_binary, 
-              :is_integer, :lower_bound, :upper_bound, :fix_value, :start_value,
-              :set_binary, :set_integer, :LowerBoundRef, :UpperBoundRef, :FixRef, 
-              :BinaryRef, :IntegerRef, :delete_lower_bound, :delete_upper_bound, 
+    for f in (:has_lower_bound, :has_upper_bound, :lower_bound, :upper_bound, 
+              :fix_value, :start_value, :set_binary, :set_integer, 
+              :LowerBoundRef, :UpperBoundRef, :FixRef, :BinaryRef, :IntegerRef, 
+              :delete_lower_bound, :delete_upper_bound, 
               :unfix, :unset_binary, :unset_integer)
         @test_throws ArgumentError eval(f)(dvref)
         @test_throws ArgumentError eval(f)(gvref)
+    end
+    for f in (:is_fixed, :is_binary, :is_integer)
+        @test !eval(f)(dvref)
+        @test !eval(f)(gvref)
     end
     # test setting methods
     for f in (:set_lower_bound, :set_upper_bound, :set_start_value)


### PR DESCRIPTION
This is needed for the DisjunctiveProgramming extension which checks every term in an expression with `JuMP.is_binary`.
