### PR TITLE
Map finite parameters to JuMP.Parameters

### DIFF
--- a/docs/src/guide/transcribe.md
+++ b/docs/src/guide/transcribe.md
@@ -469,3 +469,13 @@ julia> supports(y^2 + z - 42)
 julia> parameter_refs(y^2 + z - 42)
 (t,)
 ```
+For finite parameters, we can also retrieve their corresponding `JuMP` parameter with `transformation_variable`.
+```jldoctest transcribe
+julia> param = @finite_parameter(inf_model, p == 42)
+p
+
+julia> build_transformation_backend!(inf_model)
+
+julia> transformation_variable(p)
+p
+```

--- a/docs/src/manual/transcribe.md
+++ b/docs/src/manual/transcribe.md
@@ -8,6 +8,7 @@ InfiniteOpt.TranscriptionOpt.TranscriptionBackend
 InfiniteOpt.TranscriptionOpt.TranscriptionData
 InfiniteOpt.TranscriptionOpt.Transcription
 InfiniteOpt.TranscriptionOpt.set_parameter_supports
+InfiniteOpt.TranscriptionOpt.transcribe_finite_parameters!
 InfiniteOpt.TranscriptionOpt.transcribe_finite_variables!
 InfiniteOpt.TranscriptionOpt.transcribe_infinite_variables!
 InfiniteOpt.TranscriptionOpt.transcribe_derivative_variables!

--- a/src/TranscriptionOpt/model.jl
+++ b/src/TranscriptionOpt/model.jl
@@ -337,13 +337,13 @@ const FinVarIndex = Union{
     }
 
 ## Define the variable mapping functions
-# FinVarIndex
+# FinVarIndex & FiniteParameterIndex
 function transcription_variable(
     vref::InfiniteOpt.GeneralVariableRef,
     ::Type{V},
     backend::TranscriptionBackend,
     label::Type{<:InfiniteOpt.AbstractSupportLabel}
-    ) where {V <: FinVarIndex}
+    ) where {V <: Union{FinVarIndex, InfiniteOpt.FiniteParameterIndex}}
     var = get(transcription_data(backend).finvar_mappings, vref, nothing)
     if isnothing(var)
         error("Variable reference $vref not used in transcription backend.")
@@ -551,7 +551,7 @@ function lookup_by_support(
     ::Type{V},
     backend::TranscriptionBackend,
     support::Vector
-    ) where {V <: FinVarIndex}
+    ) where {V <: Union{FinVarIndex, InfiniteOpt.FiniteParameterIndex}}
     if !haskey(transcription_data(backend).finvar_mappings, vref)
         error("Variable reference $vref not used in transcription backend.")
     end

--- a/src/TranscriptionOpt/transcribe.jl
+++ b/src/TranscriptionOpt/transcribe.jl
@@ -65,7 +65,6 @@ stored in `model` and add it to `backend`. The variable mapping is
 also stored in `TranscriptionData.finvar_mappings` which enables
 [`transcription_variable`](@ref) and [`lookup_by_support`](@ref).
 """
-
 function transcribe_finite_parameters!(
     backend::TranscriptionBackend,
     model::InfiniteOpt.InfiniteModel

--- a/src/TranscriptionOpt/transcribe.jl
+++ b/src/TranscriptionOpt/transcribe.jl
@@ -76,13 +76,9 @@ function transcribe_finite_parameters!(
         # Prepare arguments for building JuMP parameter
         name = object.name
         pValue = object.parameter.value
-        pset = MOI.Parameter(pValue)
-        variableData = JuMP.VariableInfo(false, NaN, false, NaN, false, NaN, false, NaN, false, false)
         
         # Build the JuMP variable and add it to the backend
-        baseParam = JuMP.ScalarVariable(variableData)
-        p = JuMP.VariableConstrainedOnCreation(baseParam, pset)
-        pref = JuMP.add_variable(backend.model, p, name)
+        pref = JuMP.@variable(backend.model, base_name = name, set = MOI.Parameter(pValue))
         transcription_data(backend).finvar_mappings[fpref] = pref
     end
     return

--- a/test/TranscriptionOpt/model.jl
+++ b/test/TranscriptionOpt/model.jl
@@ -404,10 +404,12 @@ end
     @variable(tb.model, b)
     @variable(tb.model, c)
     @variable(tb.model, d)
+    @variable(tb.model, e in Parameter(42))
     # transcribe the variables and measures
     data = IOTO.transcription_data(tb)
     data.finvar_mappings[y] = a
     data.finvar_mappings[x0] = a
+    data.finvar_mappings[finpar] = e
     data.infvar_mappings[x] = reshape([a, b], :, 1)
     data.measure_mappings[meas1] = fill(-2 * zero(AffExpr))
     data.measure_mappings[meas2] = [a^2 + c^2 - 2a, b^2 + d^2 - 2a]
@@ -450,7 +452,7 @@ end
     end
     # test transcription expression for finite parameters with 3 args
     @testset "IOTO.transcription_expression (Finite Parameter)" begin
-        @test IOTO.transcription_expression(finpar, tb, [0.5, 1., 0.]) == 42
+        @test IOTO.transcription_expression(finpar, tb, [0.5, 1., 0.]) == e
     end
     # test transcription expression for AffExprs with 3 args
     @testset "IOTO.transcription_expression (AffExpr)" begin

--- a/test/TranscriptionOpt/transcribe.jl
+++ b/test/TranscriptionOpt/transcribe.jl
@@ -535,7 +535,7 @@ end
     dt_c1 = IOTO.lookup_by_support(d1, tb, zeros(3))
     @test constraint_object(IOTO.transcription_constraint(c1)).func == -zt + xt[1] + dt_c1
     @test constraint_object(IOTO.transcription_constraint(c2)).func == zt + xt[1]
-    expected = IOTO.transcription_variable(meas2)[2] - 2 * IOTO.transcription_variable(y0) + xt[2]
+    expected = IOTO.transcription_variable(meas2)[2] - 2 * IOTO.transcription_variable(y0) + xt[2] + IOTO.transcription_variable(fin)
     @test constraint_object(IOTO.transcription_constraint(c4)).func == expected
     @test constraint_object(IOTO.transcription_constraint(c3)).func == xt[1] - 2wt + xt[2] + zt - d2t[1] - d2t[2]
     @test constraint_object(IOTO.transcription_constraint(c6)).func == [zt, wt]


### PR DESCRIPTION
Currently, finite parameters are transcribed as scalar values and can only be updated by remaking the JuMP backend from scratch. This PR makes it easier to update finite parameter values by transcribing them as `JuMP.Parameter`s instead, avoiding the need to remake the JuMP backend.
