### PR TITLE
Add `filter_constraints` kwarg to `copy_model(::InfiniteModel)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InfiniteOpt"
 uuid = "20393b10-9daf-11e9-18c9-8db751c92c57"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Joshua Pulsipher and colleagues"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InfiniteOpt"
 uuid = "20393b10-9daf-11e9-18c9-8db751c92c57"
-version = "0.6.2"
+version = "0.6.1"
 authors = ["Joshua Pulsipher and colleagues"]
 
 [deps]

--- a/src/copy.jl
+++ b/src/copy.jl
@@ -132,48 +132,6 @@ end
 # Generic fallback
 _rewrite_constraint(c, ::InfiniteReferenceMap) = c
 
-## Decide whether an `obj_dict` entry should survive the copy. An
-## entry is dropped if it (or, for a container, any element of it)
-## points at a variable that was deleted in the source or a constraint
-## that was not copied (deleted in the source, or removed by
-## `filter_constraints`). `source_to_new` is populated only for
-## constraints actually copied, so checking membership there covers
-## both cases.
-
-# Scalar variable ref: drop if invalid in source
-function _copyable_obj_dict_entry(
-    model::InfiniteModel,
-    ::InfiniteReferenceMap,
-    v::GeneralVariableRef
-    )
-    return JuMP.is_valid(model, v)
-end
-
-# Scalar constraint ref: drop if its source index was not copied
-function _copyable_obj_dict_entry(
-    ::InfiniteModel,
-    ref_map::InfiniteReferenceMap,
-    v::InfOptConstraintRef
-    )
-    return haskey(ref_map.source_to_new, JuMP.index(v))
-end
-
-# Container of refs: drop the whole name if any element is uncopyable
-function _copyable_obj_dict_entry(
-    model::InfiniteModel,
-    ref_map::InfiniteReferenceMap,
-    v::AbstractArray
-    )
-    return all(
-        _copyable_obj_dict_entry(model, ref_map, el) for el in v
-        )
-end
-
-# Generic fallback: pure-data / unhandled types pass through
-_copyable_obj_dict_entry(
-    ::InfiniteModel, ::InfiniteReferenceMap, ::Any
-    ) = true
-
 ################################################################################
 #                              COPY MODEL
 ################################################################################
@@ -394,11 +352,19 @@ function JuMP.copy_model(
     # constraints that were not copied (deleted in source or filtered
     # out) are skipped, so the copy never carries dangling references.
     # For container registrations, the whole name is dropped if any
-    # element is uncopyable (see `_copyable_obj_dict_entry`).
+    # element is uncopyable. `source_to_new` is populated only for
+    # constraints actually copied, so its `haskey` check covers both
+    # "deleted in source" and "filtered out" in one test.
+    keep(v) =
+        v isa GeneralVariableRef ? JuMP.is_valid(model, v) :
+        v isa InfOptConstraintRef ?
+            haskey(ref_map.source_to_new, JuMP.index(v)) :
+        v isa AbstractArray ? all(keep, v) :
+        true
     new_model.obj_dict = Dict(
         k => ref_map[v]
         for (k, v) in model.obj_dict
-        if _copyable_obj_dict_entry(model, ref_map, v)
+        if keep(v)
         )
 
     # Backend / ready_to_optimize already set fresh by InfiniteModel()

--- a/src/copy.jl
+++ b/src/copy.jl
@@ -132,11 +132,56 @@ end
 # Generic fallback
 _rewrite_constraint(c, ::InfiniteReferenceMap) = c
 
+## Decide whether an `obj_dict` entry should survive the copy. An
+## entry is dropped if it (or, for a container, any element of it)
+## points at a variable that was deleted in the source or a constraint
+## that was not copied (deleted in the source, or removed by
+## `filter_constraints`). `source_to_new` is populated only for
+## constraints actually copied, so checking membership there covers
+## both cases.
+
+# Scalar variable ref: drop if invalid in source
+function _copyable_obj_dict_entry(
+    model::InfiniteModel,
+    ::InfiniteReferenceMap,
+    v::GeneralVariableRef
+    )
+    return JuMP.is_valid(model, v)
+end
+
+# Scalar constraint ref: drop if its source index was not copied
+function _copyable_obj_dict_entry(
+    ::InfiniteModel,
+    ref_map::InfiniteReferenceMap,
+    v::InfOptConstraintRef
+    )
+    return haskey(ref_map.source_to_new, JuMP.index(v))
+end
+
+# Container of refs: drop the whole name if any element is uncopyable
+function _copyable_obj_dict_entry(
+    model::InfiniteModel,
+    ref_map::InfiniteReferenceMap,
+    v::AbstractArray
+    )
+    return all(
+        _copyable_obj_dict_entry(model, ref_map, el) for el in v
+        )
+end
+
+# Generic fallback: pure-data / unhandled types pass through
+_copyable_obj_dict_entry(
+    ::InfiniteModel, ::InfiniteReferenceMap, ::Any
+    ) = true
+
 ################################################################################
 #                              COPY MODEL
 ################################################################################
 """
-    JuMP.copy_model(model::InfiniteModel)
+    JuMP.copy_model(
+        model::InfiniteModel;
+        filter_constraints::Union{Nothing, Function} = nothing
+        )
 
 Return a copy of `model` and an [`InfiniteReferenceMap`](@ref) that
 can be used to obtain the variable and constraint references of the
@@ -162,10 +207,21 @@ Entries left in the source's object dictionary that point at deleted
 refs are skipped on the copy, so dangling registrations do not leak
 into `new_model.obj_dict`.
 
-!!! note
-    Unlike `JuMP.copy_model(::JuMP.GenericModel)`, this method does
-    not currently accept a `filter_constraints` keyword argument. All
-    constraints are copied.
+## Keyword Arguments
+
+- `filter_constraints::Union{Nothing, Function} = nothing`: when not
+  `nothing`, a predicate that receives each source `InfOptConstraintRef`
+  and returns `true` to copy it or `false` to skip it. Skipped
+  constraints are absent from `new_model.constraints` and from
+  `ref_map.source_to_new`, so `ref_map[dropped]` raises a `KeyError`
+  (the same convention `JuMP.copy_model(::GenericModel)` uses for
+  filtered constraints). Variables are not affected — a constraint's
+  variables remain in `new_model` whether or not the constraint
+  itself was copied. If a constraint registered by name in
+  `model.obj_dict` is filtered out, its name registration is dropped
+  from `new_model.obj_dict`; for a constraint container registered
+  under a single name (e.g. `@constraint(model, c[1:n], ...)`), the
+  whole name is dropped if **any** of its elements is filtered out.
 
 **Example**
 ```julia-repl
@@ -182,9 +238,21 @@ julia> new_model, ref_map = copy_model(model);
 julia> new_x = ref_map[x];
 
 julia> new_c = ref_map[c];
+
+julia> # Skip `c` on the copy:
+       new_model2, ref_map2 = copy_model(
+           model;
+           filter_constraints = cref -> cref != c
+           );
+
+julia> haskey(new_model2.obj_dict, :c)
+false
 ```
 """
-function JuMP.copy_model(model::InfiniteModel)
+function JuMP.copy_model(
+    model::InfiniteModel;
+    filter_constraints::Union{Nothing, Function} = nothing
+    )
     new_model = InfiniteModel(copy_empty_backend(model.backend))
     ref_map = InfiniteReferenceMap(model, new_model)
 
@@ -297,8 +365,14 @@ function JuMP.copy_model(model::InfiniteModel)
             _add_data_object(new_model, new_data)
     end
 
-    # Constraints
+    # Constraints — honors `filter_constraints` if provided. Skipped
+    # constraints are never inserted and never recorded in
+    # `source_to_new`, so `ref_map[dropped]` raises `KeyError`.
     for (idx, data) in model.constraints
+        if filter_constraints !== nothing &&
+           !filter_constraints(InfOptConstraintRef(model, idx))
+            continue
+        end
         new_data = copy(data)
         new_data.constraint = _rewrite_constraint(data.constraint, ref_map)
         ref_map.source_to_new[idx] =
@@ -316,13 +390,15 @@ function JuMP.copy_model(model::InfiniteModel)
 
     # obj_dict — values whose types lack a getindex method on
     # InfiniteReferenceMap pass through unchanged via the catch-all
-    # fallback. Symbol entries still registered on `model` that point
-    # at deleted refs are skipped (the macro keeps registrations after
-    # `delete!`, but the copy shouldn't carry dangling references).
+    # fallback. Entries that point at deleted variables or at
+    # constraints that were not copied (deleted in source or filtered
+    # out) are skipped, so the copy never carries dangling references.
+    # For container registrations, the whole name is dropped if any
+    # element is uncopyable (see `_copyable_obj_dict_entry`).
     new_model.obj_dict = Dict(
         k => ref_map[v]
         for (k, v) in model.obj_dict
-        if !(v isa GeneralVariableRef) || JuMP.is_valid(model, v)
+        if _copyable_obj_dict_entry(model, ref_map, v)
         )
 
     # Backend / ready_to_optimize already set fresh by InfiniteModel()

--- a/src/copy.jl
+++ b/src/copy.jl
@@ -355,12 +355,11 @@ function JuMP.copy_model(
     # element is uncopyable. `source_to_new` is populated only for
     # constraints actually copied, so its `haskey` check covers both
     # "deleted in source" and "filtered out" in one test.
-    keep(v) =
-        v isa GeneralVariableRef ? JuMP.is_valid(model, v) :
-        v isa InfOptConstraintRef ?
-            haskey(ref_map.source_to_new, JuMP.index(v)) :
-        v isa AbstractArray ? all(keep, v) :
-        true
+    keep(v::GeneralVariableRef) = JuMP.is_valid(model, v)
+    keep(v::InfOptConstraintRef) =
+        haskey(ref_map.source_to_new, JuMP.index(v))
+    keep(v::AbstractArray) = all(keep, v)
+    keep(::Any) = true
     new_model.obj_dict = Dict(
         k => ref_map[v]
         for (k, v) in model.obj_dict

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -543,3 +543,69 @@ end
     # Backends are independent instances.
     @test new_m.backend !== m.backend
 end
+
+@testset "copy_model filter_constraints" begin
+    m = InfiniteModel()
+    @infinite_parameter(m, t in [0, 1], num_supports = 5)
+    @variable(m, x, Infinite(t))
+    @variable(m, y >= 0)
+    @constraint(m, c1, x <= 1)
+    @constraint(m, c2, y <= 5)
+
+    # `filter_constraints = nothing` is identical to omitting the kwarg
+    new_m_a, _ = copy_model(m)
+    new_m_b, _ = copy_model(m; filter_constraints = nothing)
+    @test length(new_m_a.constraints) == length(new_m_b.constraints)
+    @test haskey(new_m_a.obj_dict, :c1) &&
+          haskey(new_m_b.obj_dict, :c1)
+    @test haskey(new_m_a.obj_dict, :c2) &&
+          haskey(new_m_b.obj_dict, :c2)
+
+    # Drop the scalar `c2` only
+    new_m, ref_map = copy_model(
+        m;
+        filter_constraints =
+            cref -> JuMP.index(cref) != JuMP.index(c2)
+        )
+    @test length(new_m.constraints) == length(m.constraints) - 1
+    # Kept constraint still resolves through the ref map
+    @test JuMP.owner_model(ref_map[c1]) === new_m
+    # Dropped constraint is absent from `source_to_new`
+    @test_throws KeyError ref_map[c2]
+    # `obj_dict` keeps the surviving name and drops the filtered one
+    @test haskey(new_m.obj_dict, :c1)
+    @test !haskey(new_m.obj_dict, :c2)
+    # Variables are unaffected by constraint filtering
+    @test JuMP.owner_model(ref_map[x]) === new_m
+    @test JuMP.owner_model(ref_map[y]) === new_m
+
+    # Drop every constraint
+    new_m2, _ = copy_model(m; filter_constraints = cref -> false)
+    @test length(new_m2.constraints) == 0
+    @test !haskey(new_m2.obj_dict, :c1)
+    @test !haskey(new_m2.obj_dict, :c2)
+
+    # Container registration: partial filtering drops the whole name
+    m3 = InfiniteModel()
+    @infinite_parameter(m3, s in [0, 1], num_supports = 3)
+    @variable(m3, z[1:3], Infinite(s))
+    @constraint(m3, cv[i = 1:3], z[i] <= i)
+
+    new_m3, ref_map3 = copy_model(
+        m3;
+        filter_constraints =
+            cref -> JuMP.index(cref) != JuMP.index(cv[2])
+        )
+    @test length(new_m3.constraints) == 2
+    # One element filtered ⇒ drop the entire `:cv` name registration
+    @test !haskey(new_m3.obj_dict, :cv)
+    # Surviving elements still resolvable
+    @test JuMP.owner_model(ref_map3[cv[1]]) === new_m3
+    @test JuMP.owner_model(ref_map3[cv[3]]) === new_m3
+    @test_throws KeyError ref_map3[cv[2]]
+
+    # All-true predicate keeps the full container registration
+    new_m4, _ = copy_model(m3; filter_constraints = cref -> true)
+    @test length(new_m4.constraints) == 3
+    @test haskey(new_m4.obj_dict, :cv)
+end

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -608,4 +608,16 @@ end
     new_m4, _ = copy_model(m3; filter_constraints = cref -> true)
     @test length(new_m4.constraints) == 3
     @test haskey(new_m4.obj_dict, :cv)
+
+    # Non-ref `obj_dict` entries (anything that isn't a variable
+    # ref, a constraint ref, or a container of refs) survive the
+    # copy unchanged via the generic `keep(::Any) = true` fallback.
+    m5 = InfiniteModel()
+    @infinite_parameter(m5, u in [0, 1], num_supports = 3)
+    @variable(m5, w, Infinite(u))
+    m5[:scalar_const] = 42
+    m5[:tuple_data]   = (a = 1, b = "two")
+    new_m5, _ = copy_model(m5)
+    @test new_m5[:scalar_const] == 42
+    @test new_m5[:tuple_data]   == (a = 1, b = "two")
 end


### PR DESCRIPTION
Adds a filter_constraints::Union{Nothing, Function} keyword to `JuMP.copy_model(::InfiniteModel)`. When supplied, any source constraint for which `filter_constraints(cref)` returns false is skipped at copy time, and obj_dict entries pointing at uncopied refs (or containers with any uncopied element) are dropped so the copy carries no dangling references. Default nothing preserves current behavior.

This closes #430,

