### PR TITLE
Multi-Objective Support in InfiniteOpt

### DIFF
--- a/docs/src/examples/Optimal Control/Rocket.jl
+++ b/docs/src/examples/Optimal Control/Rocket.jl
@@ -1,0 +1,95 @@
+# # Rocket Launch
+# We will solve an optimal control problem that aims to minimize final time.
+
+# # Problem Statement and Model
+# In this problem, we seek to minimize the final time ``t_f`` of a rocket launch between 0 and 10 metres.
+# Minimizing fuel use is also important for this problem.
+# Our optimization guidelines are subject to these constraints:
+# ```math
+# \begin{gathered}
+# &&\min t_f \\
+# &&&\frac{ds}{dt}= v \\
+# &&&\frac{dv}{dt}= (u-0.2*(v^2))/2\\
+# &&&\frac{dm}{dt}= -0.01(u^2)\\
+# &&&0 \leq v(t) \leq 1.7 \\
+# &&&-1.1 \leq v(t) \leq 1.1 \\
+# &&&s(0) = 0 \\
+# &&&v(0) = 0 \\
+# &&&m(0) = 1 \\
+# &&&s(t_f) = 10 \\
+# &&&v(t_f) = 0 \\
+# \end{gathered}
+# ```
+
+# # Modeling in InfiniteOpt
+# First we must import ``InfiniteOpt`` and other packages.
+using JuMP, InfiniteOpt, Ipopt, Plots;
+
+# # Model Initialization
+# We then initialize the infinite model with [`InfiniteModel`](@ref), selecting Ipopt as the desired optimizer to solve this model.
+model = InfiniteModel(Ipopt.Optimizer);
+
+# # Infinite Parameter Definition
+# We are defining the infinite parameter ``t \in [0, 1]``. The bounds give the optimizer parameters to iterate over.
+@infinite_parameter(model, t in [0,1], num_supports = 50, derivative_method = FiniteDifference(Backward()));
+
+# # Infinite Variable Definition
+# Moving on to specifying variables, we have v as velocity of the rocket, u as the force of the rocket.
+# The position, p, and mass, m, vary over time. The final time, t_f, must be between 0.1 and 100 seconds.
+@variable(model, 0 <= v <= 1.7, Infinite(t)) 
+@variable(model, -1.1 <= u <= 1.1, Infinite(t)) 
+@variable(model, 0.1 <= t_f <= 100) 
+@variable(model, p, Infinite(t))
+@variable(model, m, Infinite(t));
+
+# # Initial and Final Condition Definition
+# Now that the model is defined, we then want to specify both our initial and final conditions.
+@constraint(model, v(0) == 0)
+@constraint(model, v(1) == 0)
+@constraint(model, p(0) == 0)
+@constraint(model, p(1) == 10)
+@constraint(model, m(0) == 1)
+@constraint(model, m(1) >= 0.2);
+
+# # Objective Definition
+# We now add the objective, using `@objective`, which is to minimize final time t_f.
+@objective(model, Min, t_f);
+
+# # Constraint Definition
+# We finally are adding our constraints, which are defining the ODEs for our system model.
+@constraint(model, v * t_f == deriv(p, t))
+@constraint(model, ((u - (0.2 * (v ^ 2))) * t_f) == (deriv(v, t)) * m) 
+@constraint(model, (-0.01 * (u ^ 2)) * t_f == deriv(m, t));
+
+# # Problem Solution
+# Now that everything is set up, we can solve the model by using `@optimize!`
+optimize!(model)
+
+# # Extract and Plot the Results
+# We can now extract the optimized results and plot them to visualize four results graphically:
+# Position over time, velocity over time, mass over time and force over time. In addition, we can print the final time value of t_f.
+tf_data = value(t_f)
+t_data = supports(t) .* tf_data
+v_data = value(v)
+p_data = value(p)
+m_data = value(m)
+u_data = value(u);
+
+# Printing the final time value.
+println("Minimized Final Time: ", tf_data," seconds");
+
+# Creating the four plots as described above. 
+plot1 = plot(t_data, v_data, title="Velocity Over Time", linecolor = :red, xlabel="Time", label = "Velocity", ylabel="Velocity", lw=2);
+plot2 = plot(t_data, p_data, title="Position Over Time", linecolor = :orange, xlabel="Time", label = "Position", ylabel="Position", lw=2);
+plot3 = plot(t_data, m_data, title="Mass Over Time", linecolor = :yellow, xlabel="Time", label = "Position", ylabel="Position", lw=2);
+plot4 = plot(t_data, u_data, title="Force Over Time", linecolor = :limegreen, xlabel="Time", label = "Position", ylabel="Position", lw=2);
+
+# Visualizing all four plots on one display.
+display(plot(plot1, plot2, plot3, plot4, layout=(4,1), size = (1000, 1000)))
+
+# ### Maintenance Tests
+# These are here to ensure this example stays up to date. 
+using Test
+tol = 1E-6
+@test termination_status(model) == MOI.LOCALLY_SOLVED
+@test has_values(model)

--- a/docs/src/examples/Optimal Control/Rocket.jl
+++ b/docs/src/examples/Optimal Control/Rocket.jl
@@ -94,6 +94,7 @@ display(plot(plot1, plot2, plot3, plot4, layout=(4,1), size = (1000, 1000)))
 # ### Maintenance Tests
 # These are here to ensure this example stays up to date. 
 using Test
-tol = 1E-6
+tol = 1E-4
 @test termination_status(model) == MOI.LOCALLY_SOLVED
 @test has_values(model)
+@test isapprox(objective_value(model), 7.4482495165303710, atol=tol)

--- a/docs/src/examples/Optimal Control/Rocket.jl
+++ b/docs/src/examples/Optimal Control/Rocket.jl
@@ -3,23 +3,27 @@
 
 # # Problem Statement and Model
 # In this problem, we seek to minimize the final time ``t_f`` of a rocket launch between 0 and 10 metres.
-# Minimizing fuel use is also important for this problem.
+# Minimizing fuel use is also important for this problem. The force- or thrust- of the rocket can be between
+# -1.1 and 1.1, while the velocity of the rocket cannot exceed 1.7. The drag resistance of the rocket is
+# proportional to the square of the velocity. The mass of the rocket decreases as fuel is burned over time. 
 # Our optimization guidelines are subject to these constraints:
 # ```math
-# \begin{gathered}
-# &&\min t_f \\
-# &&&\frac{ds}{dt}= v \\
-# &&&\frac{dv}{dt}= (u-0.2*(v^2))/2\\
-# &&&\frac{dm}{dt}= -0.01(u^2)\\
-# &&&0 \leq v(t) \leq 1.7 \\
-# &&&-1.1 \leq v(t) \leq 1.1 \\
-# &&&s(0) = 0 \\
-# &&&v(0) = 0 \\
-# &&&m(0) = 1 \\
-# &&&s(t_f) = 10 \\
-# &&&v(t_f) = 0 \\
-# \end{gathered}
+# \begin{aligned}
+#   &&\min t_f \\
+#   &&&\frac{ds}{dt}= v \\
+#   &&&\frac{dv}{dt}= (u-0.2*(v^2))/2\\
+#   &&&\frac{dm}{dt}= -0.01(u^2)\\
+#   &&&0 \leq v(t) \leq 1.7 \\
+#   &&&-1.1 \leq u(t) \leq 1.1 \\
+#       &&&s(0) = 0 \\
+#       &&&v(0) = 0 \\
+#       &&&m(0) = 1 \\
+#       &&&s(t_f) = 10 \\
+#       &&&v(t_f) = 0 \\
+# \end{aligned}
 # ```
+# where ``v(t)`` represents the rocket's velocity, ``s(t)`` represents the rocket's position and
+# ``m(t)`` represents the rocket's mass. Additionally, ``u(t)`` represents the rocket's force (or thrust).
 
 # # Modeling in InfiniteOpt
 # First we must import ``InfiniteOpt`` and other packages.

--- a/docs/src/guide/objective.md
+++ b/docs/src/guide/objective.md
@@ -151,7 +151,7 @@ These models are defined the same way as scalar, single-objective models with `@
 julia> set_objective(model, MOI.MAX_SENSE, [0.5x[1], 0.5x[2]])
 
 julia> @objective(model, Max, [0.5x[1], 0.5x[2]])
-2-element Vector{GenericAffExpr{Float64, GeneralVariableRef}}:2-element Vector{GenericAffExpr{Float64, GeneralVariableRef}}:
+2-element Vector{GenericAffExpr{Float64, GeneralVariableRef}}:
 0.5 x[1]
 0.5 x[2]
 ```

--- a/docs/src/guide/objective.md
+++ b/docs/src/guide/objective.md
@@ -151,9 +151,10 @@ These models are defined the same way as scalar, single-objective models with `@
 julia> set_objective(model, MOI.MAX_SENSE, [0.5x[1], 0.5x[2]])
 
 julia> @objective(model, Max, [0.5x[1], 0.5x[2]])
+2-element Vector{GenericAffExpr{Float64, GeneralVariableRef}}:2-element Vector{GenericAffExpr{Float64, GeneralVariableRef}}:
 0.5 x[1]
 0.5 x[2]
 ```
 If a scalarization method of solving the model is the goal, the individual `@expression` scalars within the vector can be compiled into a single objective. The weight- or priority- of these expressions can be changed by multiplying each component in the vector by fractions, with the sum of the fractions being 1.
 In hierarchical model solving, the order of the scalars determines the priority of the model.
-For more solvers that support multiple objective optimization, please refer to `JuMP` solvers, such as [`@MultiObjectiveAlgorithms`](https://jump.dev/JuMP.jl/stable/packages/MultiObjectiveAlgorithms/#MultiObjectiveAlgorithms.jl) and [`@Gurobi`](https://jump.dev/JuMP.jl/stable/packages/Gurobi/#Gurobi.jl).
+For more solvers that support multiple objective optimization, please refer to `JuMP` solvers, such as [MultiObjectiveAlgorithms](https://jump.dev/JuMP.jl/stable/packages/MultiObjectiveAlgorithms/#MultiObjectiveAlgorithms.jl) and [Gurobi](https://jump.dev/JuMP.jl/stable/packages/Gurobi/#Gurobi.jl).

--- a/docs/src/guide/objective.md
+++ b/docs/src/guide/objective.md
@@ -152,8 +152,8 @@ julia> set_objective(model, MOI.MAX_SENSE, [0.5x[1], 0.5x[2]])
 
 julia> @objective(model, Max, [0.5x[1], 0.5x[2]])
 2-element Vector{GenericAffExpr{Float64, GeneralVariableRef}}:
-0.5 x[1]
-0.5 x[2]
+ 0.5 x[1]
+ 0.5 x[2]
 ```
 If a scalarization method of solving the model is the goal, the individual `@expression` scalars within the vector can be compiled into a single objective. The weight- or priority- of these expressions can be changed by multiplying each component in the vector by fractions, with the sum of the fractions being 1.
 In hierarchical model solving, the order of the scalars determines the priority of the model.

--- a/docs/src/guide/objective.md
+++ b/docs/src/guide/objective.md
@@ -14,6 +14,7 @@ One key idea is that the objective must evaluate to a finite expression which me
 it must only explicitly contain finite variables and point variables. Infinite 
 expressions must be summarized by a measure (e.g., taking the expectation of a random variable).
 
+
 ## [Basic Usage](@id obj_basic)
 Principally, the objective function is specified via 
 [`@objective`](https://jump.dev/JuMP.jl/v1/api/JuMP/#JuMP.@objective) 
@@ -139,3 +140,17 @@ more efficient at parsing expressions.
     [`@objective`](https://jump.dev/JuMP.jl/v1/api/JuMP/#JuMP.@objective) 
     since it is more stable and efficient than the `set_objective_[aspect]` 
     methods due to its enhanced methodology for parsing expressions.
+
+### Multi-Objective Problems
+`InfiniteOpt` also supports multi-objective problems by supplying the model with a vector of scalar values.
+Instead of a `JuMP.AbstractJuMPScalar`, these become `AbstractVector` within the model.
+
+These models are defined the same way as scalar, single-objective models with `@objective`, with some slight differences in definition. Looking at the aforementioned example and modifying it a bit, it becomes:
+
+```jldoctest obj_multi
+julia> @objective(model, Max, [0.5x[1], 0.5x[2]])
+ 0.5 x[1]
+ 0.5 x[2]
+```
+If a scalarization method of solving the model is the goal, the individual `@expression` scalars within the vector can be compiled into a single objective. The weight- or priority- of these expressions can be changed by multiplying each component in the vector by fractions, with the sum of the fractions being 1.
+In hierarchical model solving, the order of the scalars determines the priority of the model.

--- a/docs/src/guide/objective.md
+++ b/docs/src/guide/objective.md
@@ -149,8 +149,10 @@ These models are defined the same way as scalar, single-objective models with `@
 
 ```jldoctest obj
 julia> set_objective(model, MOI.MAX_SENSE, [0.5x[1], 0.5x[2]])
- 0.5 x[1]
- 0.5 x[2]
+
+julia> @objective(model, Max, [0.5x[1], 0.5x[2]])
+0.5 x[1]
+0.5 x[2]
 ```
 If a scalarization method of solving the model is the goal, the individual `@expression` scalars within the vector can be compiled into a single objective. The weight- or priority- of these expressions can be changed by multiplying each component in the vector by fractions, with the sum of the fractions being 1.
 In hierarchical model solving, the order of the scalars determines the priority of the model.

--- a/docs/src/guide/objective.md
+++ b/docs/src/guide/objective.md
@@ -148,7 +148,7 @@ Instead of a `JuMP.AbstractJuMPScalar`, these become `AbstractVector` within the
 These models are defined the same way as scalar, single-objective models with `@objective`, with some slight differences in definition. Looking at the aforementioned example and modifying it a bit, it becomes:
 
 ```jldoctest obj
-julia> set_objective(model, Max, [0.5x[1], 0.5x[2]])
+julia> set_objective(model, MOI.MAX_SENSE, [0.5x[1], 0.5x[2]])
  0.5 x[1]
  0.5 x[2]
 ```

--- a/docs/src/guide/objective.md
+++ b/docs/src/guide/objective.md
@@ -147,10 +147,11 @@ Instead of a `JuMP.AbstractJuMPScalar`, these become `AbstractVector` within the
 
 These models are defined the same way as scalar, single-objective models with `@objective`, with some slight differences in definition. Looking at the aforementioned example and modifying it a bit, it becomes:
 
-```jldoctest obj_multi
-julia> @objective(model, Max, [0.5x[1], 0.5x[2]])
+```jldoctest obj
+julia> set_objective(model, Max, [0.5x[1], 0.5x[2]])
  0.5 x[1]
  0.5 x[2]
 ```
 If a scalarization method of solving the model is the goal, the individual `@expression` scalars within the vector can be compiled into a single objective. The weight- or priority- of these expressions can be changed by multiplying each component in the vector by fractions, with the sum of the fractions being 1.
 In hierarchical model solving, the order of the scalars determines the priority of the model.
+For more solvers that support multiple objective optimization, please refer to `JuMP` solvers, such as [`@MultiObjectiveAlgorithms`](https://jump.dev/JuMP.jl/stable/packages/MultiObjectiveAlgorithms/#MultiObjectiveAlgorithms.jl) and [`@Gurobi`](https://jump.dev/JuMP.jl/stable/packages/Gurobi/#Gurobi.jl).

--- a/src/TranscriptionOpt/transcribe.jl
+++ b/src/TranscriptionOpt/transcribe.jl
@@ -565,6 +565,15 @@ function transcription_expression(
     return zero(JuMP.AffExpr) + num
 end
 
+# Vectors
+function transcription_expression(
+    func::AbstractVector,
+    backend::TranscriptionBackend,
+    support::Vector{Float64}
+    )
+    return map(f -> transcription_expression(f, backend, support), func)
+end
+
 ################################################################################
 #                         MEASURE TRANSCRIPTION METHODS
 ################################################################################
@@ -750,7 +759,7 @@ end
 function _process_constraint(
     backend::TranscriptionBackend, 
     constr::JuMP.VectorConstraint, 
-    func::Vector{<:JuMP.AbstractJuMPScalar}, 
+    func::AbstractVector,
     set::MOI.AbstractVectorSet, 
     raw_supp::Vector{Float64}, 
     name::String

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -1398,7 +1398,7 @@ mutable struct InfiniteModel <: JuMP.AbstractModel
 
     # Objective Data
     objective_sense::MOI.OptimizationSense
-    objective_function::JuMP.AbstractJuMPScalar
+    objective_function::Union{JuMP.AbstractJuMPScalar, AbstractVector{<:JuMP.AbstractJuMPScalar}}
     objective_has_measures::Bool
 
     # Operator Registration

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -18,18 +18,24 @@ function JuMP.objective_sense(model::InfiniteModel)::MOI.OptimizationSense
 end
 
 """
-    JuMP.objective_function(model::InfiniteModel)::JuMP.AbstractJuMPScalar
+    JuMP.objective_function(model::InfiniteModel)::Union{JuMP.AbstractJuMPScalar, AbstractVector}
 
 Extend `JuMP.objective_function` to return the objective of infinite model 
-`model`.
+`model`. Supports scalar values or vectors of scalar values.
 
 **Example**
 ```julia-repl
-julia> objective_function(model)
-1
+julia> objective_function(scalar_model)
+2 x + 1
+
+```julia-repl
+julia> objective_function(multiobjective_model)
+2 x + 1
+5 y - 1
+
 ```
 """
-function JuMP.objective_function(model::InfiniteModel)::JuMP.AbstractJuMPScalar
+function JuMP.objective_function(model::InfiniteModel)::Union{JuMP.AbstractJuMPScalar, AbstractVector}
     return model.objective_function
 end
 
@@ -74,11 +80,12 @@ end
 ################################################################################
 """
     JuMP.set_objective_function(model::InfiniteModel,
-                                func::JuMP.AbstractJuMPScalar)::Nothing
+                                func::Union{JuMP.AbstractJuMPScalar, AbstractVector})::Nothing
 
 Extend `JuMP.set_objective_function` to set the objective expression of
 infinite model `model`. Errors if `func` contains infinite variables and/or
-parameters. Also errors if `func` contains invalid variables.
+parameters. Also errors if `func` contains invalid variables. 
+Supports scalar values or vectors of scalar values.
 
 **Example**
 ```julia-repl
@@ -86,11 +93,17 @@ julia> set_objective_function(model, 2x + 1)
 
 julia> objective_function(model)
 2 x + 1
+
+julia> set_objective_function(model, [2x + 1, 5y - 1)
+
+julia> objective_function(model)
+2 x + 1
+5 y - 1
 ```
 """
 function JuMP.set_objective_function(
     model::InfiniteModel,
-    func::JuMP.AbstractJuMPScalar
+    func::Union{JuMP.AbstractJuMPScalar, AbstractVector}
     )::Nothing
     # gather the unique list of variable references for testing and mapping
     new_vrefs = all_expression_variables(func)
@@ -172,11 +185,11 @@ end
 
 """
     JuMP.set_objective(model::InfiniteModel, sense::MOI.OptimizationSense,
-                       func::Union{JuMP.AbstractJuMPScalar, Real})::Nothing
+                       func::Union{JuMP.AbstractJuMPScalar, AbstractVector, Real})::Nothing
 
 Extend `JuMP.set_objective` to set the objective of infinite model
 `model`. Errors if `func` contains infinite variables and/or parameters, or if
-it does not belong to the model.
+it does not belong to the model. Supports scalar values or vectors of scalar values.
 
 **Example**
 ```julia-repl
@@ -184,12 +197,18 @@ julia> set_objective(model, MOI.MIN_SENSE, 2x + 1)
 
 julia> objective_function(model)
 2 x + 1
+
+julia> set_objective(model, MOI.MIN_SENSE, [2x + 1, 5y - 1])
+
+julia> objective_function(model)
+2 x + 1
+5 y - 1
 ```
 """
 function JuMP.set_objective(
     model::InfiniteModel, 
     sense::MOI.OptimizationSense,
-    func::Union{JuMP.AbstractJuMPScalar, Real}
+    func::Union{JuMP.AbstractJuMPScalar, AbstractVector, Real}
     )::Nothing
     JuMP.set_objective_sense(model, sense)
     JuMP.set_objective_function(model, func)

--- a/test/TranscriptionOpt/transcribe.jl
+++ b/test/TranscriptionOpt/transcribe.jl
@@ -380,6 +380,27 @@ end
     end
 end
 
+# Test multi-objective transcription_expression
+@testset "Objective Transcription" begin 
+    # setup
+    m = InfiniteModel()
+    @infinite_parameter(m, t in [0, 1], supports = [0, 0.5, 1])
+    @variable(m, z, Infinite(t))
+    @variable(m, x >= 0, Infinite(t))
+    
+    tb = m.backend
+    IOTO.set_parameter_supports(tb, m)
+    IOTO.transcribe_finite_variables!(tb, m)
+    IOTO.transcribe_infinite_variables!(tb, m)
+    multi_obj = [0.5 * z, 5.0 * x] 
+    vec = IOTO.transcription_expression(multi_obj, tb, [0.5])
+
+    # main test
+    @test vec isa AbstractVector
+    @test length(vec) == length(multi_obj)
+    @test all(v -> v isa JuMP.AbstractJuMPScalar, vec)
+end
+
 # Test transcribe_derivative_evaluations! (TODO SEE IF THIS CAN BE MADE TO WORK WITH DEPENDENT PARAMETER BASED DERIVATIVES)
 @testset "transcribe_derivative_evaluations!" begin 
     # setup 

--- a/test/objective.jl
+++ b/test/objective.jl
@@ -28,6 +28,11 @@
         m.objective_function = x + meas + pt
         # test new function
         @test isequal(objective_function(m), x + meas + pt)
+        # change function (vector)
+        multi_obj = [x + pt, 5.0 * meas]
+        m.objective_function = multi_obj
+        @test objective_function(m) isa AbstractVector
+        @test length(objective_function(m)) == length(multi_obj)
         # undo changes
         m.objective_function = zero(GenericAffExpr{Float64, GeneralVariableRef})
     end
@@ -191,5 +196,33 @@ end
         set_objective_function(m, 2)
         @test isa(set_objective_coefficient(m, pt, 2), Nothing)
         @test isequal_canonical(objective_function(m), 2pt + 2)
+    end
+end
+
+@testset "Multi-Objective" begin
+    # initialize the model, references, and other info
+    m = InfiniteModel()
+    @infinite_parameter(m, par in [0, 1])
+    @variable(m, inf, Infinite(par))
+    @variable(m, pt, Point(inf, 0.5))
+    @variable(m, x)
+    data = TestData(par, 0, 1)
+    meas = measure(x, data, name = "test")
+
+    # test set_objective_coefficient
+    @testset "JuMP.set_objective_coefficient" begin
+        multi_obj = [x + pt, 5.0 * meas]    
+        # test set_objective_function
+        @test isa(set_objective_function(m, multi_obj), Nothing)
+        @test objective_function(m) == multi_obj
+        @test used_by_objective(x)
+        @test used_by_objective(pt)
+        @test used_by_objective(meas)
+        @test objective_has_measures(m)
+        @test !transformation_backend_ready(m)
+        # test set_objective
+        @test isa(set_objective(m, MOI.MAX_SENSE, [x, pt]), Nothing)
+        @test objective_sense(m) == MOI.MAX_SENSE
+        @test length(objective_function(m)) == length(multi_obj)
     end
 end


### PR DESCRIPTION
Added support for multiple objectives within InfiniteOpt by modifying the previous support for scalars to vectors of scalars. Modified the relevant doc strings and added a subsection in the objective Markdown file.