### PR TITLE
Fix transcription of vector constraints with constant components

### DIFF
--- a/src/TranscriptionOpt/transcribe.jl
+++ b/src/TranscriptionOpt/transcribe.jl
@@ -765,6 +765,9 @@ function _process_constraint(
     name::String
     )
     new_func = map(f -> transcription_expression(f, backend, raw_supp), func)
+    # promote to a common type (constant rows transcribe to numbers)
+    NewType = mapreduce(typeof, promote_type, new_func)
+    new_func = convert.(NewType, new_func)
     shape = JuMP.shape(constr)
     shaped_func = JuMP.reshape_vector(new_func, shape)
     shaped_set = JuMP.reshape_set(set, shape)

--- a/test/TranscriptionOpt/transcribe.jl
+++ b/test/TranscriptionOpt/transcribe.jl
@@ -322,11 +322,19 @@ end
         @test num_constraints(tb.model, typeof(func), typeof(set)) == 1
         cref = constraint_by_name(tb.model, "test2")
         delete(tb.model, cref)
-        # test nonlinear vector constraint 
+        # test nonlinear vector constraint
         con = VectorConstraint([sin(z)], MOI.Zeros(1))
         func = [sin(z)]
         set = MOI.Zeros(1)
         @test IOTO._process_constraint(tb, con, func, set, zeros(3), "test2") isa ConstraintRef
+        # test vector constraint with a constant entry (rows promote)
+        aff3 = zero(JuMP.GenericAffExpr{Float64, GeneralVariableRef}) + 3
+        con = VectorConstraint([1z, aff3], MOI.Nonnegatives(2))
+        func = [1z, aff3]
+        set = MOI.Nonnegatives(2)
+        @test IOTO._process_constraint(tb, con, func, set, zeros(3), "test3") isa ConstraintRef
+        cref = constraint_by_name(tb.model, "test3")
+        delete(tb.model, cref)
         # fallback
         @test_throws ErrorException IOTO._process_constraint(tb, :bad, func, set, 
                                                              zeros(3), "bad")


### PR DESCRIPTION
Vector constraints with a constant  (e.g. a cone with one fixed entry) builds fine but errors during transcription. The constant row is stored as a GenericAffExpr with no variable, then transcription makes it a Float64. This creates mixed elements which is rejected by moi_function inside _process_constraint (src/TranscriptionOpt/transcribe.jl).

Another option is to change `map_expression `but it looks like that would convert things that are actually Float64 into GenericAffExpr indiscriminately. 

Fixes #440